### PR TITLE
Add Share button to LocationTracking view for social sharing

### DIFF
--- a/app/views/LocationTracking.js
+++ b/app/views/LocationTracking.js
@@ -17,6 +17,7 @@ import {
   MenuOption,
   MenuTrigger,
 } from 'react-native-popup-menu';
+import Share from 'react-native-share';
 import colors from '../constants/colors';
 import LocationServices from '../services/LocationService';
 import BackgroundGeolocation from '@mauron85/react-native-background-geolocation';
@@ -101,6 +102,22 @@ class LocationTracking extends Component {
   licenses() {
     this.props.navigation.navigate('LicensesScreen', {});
   }
+
+  onShare = async () => {
+    try {
+      Share.open({
+        message: `${languages.t('label.private_kit')} - ${languages.t('label.intro1_para1')} ${languages.t('label.private_kit_url')}`,
+      })
+        .then(res => {
+          console.log(res);
+        })
+        .catch(err => {
+          console.log(err.message, err.code);
+        });
+    } catch (error) {
+      console.log(error.message);
+    }
+  };
 
   willParticipate = () => {
     SetStoreData('PARTICIPATE', 'true').then(() => LocationServices.start());
@@ -249,6 +266,19 @@ class LocationTracking extends Component {
                 {languages.t('label.news')}
               </Text>
             </TouchableOpacity>
+
+            <TouchableOpacity
+              onPress={() => this.onShare()}
+              style={styles.actionButtonsTouchable}>
+              <Image
+                style={styles.actionButtonImage}
+                source={news}
+                resizeMode={'contain'}
+              />
+              <Text style={styles.actionButtonText}>
+                Share
+              </Text>
+            </TouchableOpacity>
           </View>
         </ScrollView>
 
@@ -371,7 +401,7 @@ const styles = StyleSheet.create({
     height: 76,
     borderRadius: 8,
     backgroundColor: '#454f63',
-    width: width * 0.23,
+    width: width * 0.17,
     justifyContent: 'center',
     alignItems: 'center',
   },


### PR DESCRIPTION
Closes #149 

A new `Share` button has been added to the LocationTracking view that when clicked will open the share sheet native the OS. The default text of the message is the name of the application and
a simple description.

This was modeled off the sharing done by the data sharing button except this uses the `message` property of `Share` instead of `url`. 

TODO: 
* the icon should be updated since it is using the News icon
* possibly update the text in the shared message

iOS
![image](https://user-images.githubusercontent.com/471801/77349993-dc841b80-6d09-11ea-8d5b-84e9260c8038.png)

![image](https://user-images.githubusercontent.com/471801/77350014-e574ed00-6d09-11ea-8971-ad6e3ab49867.png)

Android
![image](https://user-images.githubusercontent.com/471801/77350135-0e957d80-6d0a-11ea-8b16-bdd560cee67d.png)

![image](https://user-images.githubusercontent.com/471801/77350453-8b285c00-6d0a-11ea-92ee-f810fd501e7c.png)