### PR TITLE
iOS Google Takeout file Download Fixes #77

### DIFF
--- a/app/helpers/GoogleTakeOutAutoImport.js
+++ b/app/helpers/GoogleTakeOutAutoImport.js
@@ -15,7 +15,7 @@ let progress;
 let takeoutZip = /^takeout[\w,\s-]+\.zip$/gm;
 
 // Download directory based on Platform OS
-var downloadDir =
+let downloadDir =
   Platform.OS === 'ios'
     ? RNFS.DocumentDirectoryPath + '/Downloads/'
     : RNFS.DownloadDirectoryPath;

--- a/app/views/Import.js
+++ b/app/views/Import.js
@@ -9,6 +9,7 @@ import {
   BackHandler,
   Dimensions,
   ActivityIndicator,
+  Platform,
 } from 'react-native';
 
 import colors from '../constants/colors';
@@ -75,6 +76,17 @@ class ImportScreen extends Component {
               source={{
                 uri:
                   'https://takeout.google.com/settings/takeout/custom/location_history',
+              }}
+              // capture download url on ios
+              onShouldStartLoadWithRequest={event => {
+                if (
+                  Platform.OS === 'ios' &&
+                  event.url.includes('apidata.googleusercontent')
+                ) {
+                  SaveTakeoutFile(event.url);
+                  return false;
+                }
+                return true;
               }}
               onLoad={() => this.hideSpinner()}
               style={{ marginTop: 15 }}

--- a/app/views/Import.js
+++ b/app/views/Import.js
@@ -15,7 +15,10 @@ import {
 import colors from '../constants/colors';
 import WebView from 'react-native-webview';
 import backArrow from './../assets/images/backArrow.png';
-import { SearchAndImport } from '../helpers/GoogleTakeOutAutoImport';
+import {
+  SearchAndImport,
+  SaveTakeoutFile,
+} from '../helpers/GoogleTakeOutAutoImport';
 import languages from './../locales/languages';
 const width = Dimensions.get('window').width;
 const height = Dimensions.get('window').height;


### PR DESCRIPTION
Fixes #77 

This existing react-native-webview bug will be auto-fixed in their next release with [this PR](https://github.com/react-native-community/react-native-webview/pull/1214). This fix will be a workaround to handle file downloads for iOS by:

- Intercepting WebView call to check for iOS and if url equates to takeout download url (onShouldStartLoadWithRequest)
- Creates a directory within AppData documents
- Saves the takeout file and unzips as normal

Tested on iOS and Android

