### PR TITLE
Fix small typo in dev_setup.sh

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -151,7 +151,7 @@ if ! found_exe android-studio ; then
         echo "   NOTE: You might need to close and reopent Android Studio the first time to see this."
         echo "   * Under the SDK Platforms tab, click Show Package Details"
         echo "   * Expand the 'Android 9.0 (Pie)' entry"
-        echo "     - Check: Android SDK Platform 29"
+        echo "     - Check: Android SDK Platform 28"
         echo "     - Check: Intel x86 Atom_64 System Image or Google APIs Intel x86 Atom System Image"
         echo "   * Under the SDK Tools tab, check 'Show Package Details'"
         echo "   * Expand the 'Android SDK Build-Tools' entry"


### PR DESCRIPTION
Signed-off-by: Patrick Erichsen <patrick.a.erichsen@gmail.com>

- I noticed when following along with the Android Studio setup instructions that the `Android SDK Platform 29` version number was incorrect. The only option is for `28`.

<img width="703" alt="Screen Shot 2020-04-05 at 9 48 57 PM" src="https://user-images.githubusercontent.com/20157849/78521469-8a260e80-778f-11ea-8132-6d2c83101d48.png">
