### PR TITLE
Change Export directory path for iOS

### DIFF
--- a/app/views/Export.js
+++ b/app/views/Export.js
@@ -82,7 +82,7 @@ function ExportScreen(props) {
       const filename = unixtimeUTC + '.json';
       const message = 'Here is my location log from Private Kit.';
       if (isPlatformiOS()) {
-        var url = RNFS.MainBundlePath + '/' + filename;
+        var url = RNFS.DocumentDirectoryPath + '/' + filename;
         await RNFS.writeFile(url, jsonData, 'utf8')
           .then(success => {
             options = {


### PR DESCRIPTION
`MainBundlePath` directory is not writable on iOS and hence we should use `DocumentDirectoryPath` 
This was fixed in a previous PR but got lost in merges somehow!