### PR TITLE
Location saving at proper rate; disable bluetooth

### DIFF
--- a/app/views/LocationTracking.js
+++ b/app/views/LocationTracking.js
@@ -24,7 +24,7 @@ import BackgroundImage from './../assets/images/launchScreenBackground.png';
 import BackgroundImageAtRisk from './../assets/images/backgroundAtRisk.png';
 import Colors from '../constants/colors';
 import LocationServices from '../services/LocationService';
-import BroadcastingServices from '../services/BroadcastingService';
+//import BroadcastingServices from '../services/BroadcastingService';
 import BackgroundGeolocation from '@mauron85/react-native-background-geolocation';
 import PushNotification from 'react-native-push-notification';
 import exportImage from './../assets/images/export.png';
@@ -294,7 +294,8 @@ class LocationTracking extends Component {
   willParticipate = () => {
     SetStoreData('PARTICIPATE', 'true').then(() => {
       LocationServices.start();
-      BroadcastingServices.start();
+      // Turn of bluetooth for v1
+      //BroadcastingServices.start();
     });
 
     // Check and see if they actually authorized in the system dialog.
@@ -307,7 +308,8 @@ class LocationTracking extends Component {
         });
       } else if (authorization === BackgroundGeolocation.NOT_AUTHORIZED) {
         LocationServices.stop(this.props.navigation);
-        BroadcastingServices.stop(this.props.navigation);
+        // Turn of bluetooth for v1
+        //BroadcastingServices.stop(this.props.navigation);
         this.setState({
           isLogging: false,
         });
@@ -333,7 +335,8 @@ class LocationTracking extends Component {
 
   setOptOut = () => {
     LocationServices.stop(this.props.navigation);
-    BroadcastingServices.stop(this.props.navigation);
+    // Turn of bluetooth for v1
+    //BroadcastingServices.stop(this.props.navigation);
     this.setState({
       isLogging: false,
     });


### PR DESCRIPTION
Fixes for getting the location saving to run at sane rates.   Includes:
- mimimum time allowed between saves (to protect from flooding the location log)
- maximum allowed backfill time
- Fixed backfill logic
- removed duplicate listeners, also the stationary listener that leads to duplicate location updates

Also disabled the start and stop of the BroadcastService to turn off bluetooth for v1