### PR TITLE
Build stability fixes and tweaks

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -30,7 +30,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      - name: Increase watchers for release versions.
+      - name: Increase max file watchers
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
       - name: Bundle JS

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -30,6 +30,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
+      - name: Increase watchers for release versions.
+        run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+
       - name: Bundle JS
         run: npx react-native bundle --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle --assets-dest android/app/src/main/res/ --verbose
 

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -25,8 +25,7 @@ jobs:
 
       - run: yarn --frozen-lockfile
 
-      - name: Install CocoaPods
-        run: gem install cocoapods
+      - run: gem install cocoapods
 
       - name: Cache CocoaPods
         uses: actions/cache@v1
@@ -36,8 +35,7 @@ jobs:
           restore-keys: |
             ${{ runner.OS }}-pods-
 
-      - name: Pod Install
-        run: pod install --repo-update
+      - run: pod install --repo-update
         working-directory: ./ios
 
       - name: Bundle iOS JS

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -28,10 +28,6 @@ jobs:
       - name: Install CocoaPods
         run: gem install cocoapods
 
-      - name: Update Pods
-        run: pod repo update
-        working-directory: ./ios
-
       - name: Cache CocoaPods
         uses: actions/cache@v1
         with:
@@ -41,7 +37,7 @@ jobs:
             ${{ runner.OS }}-pods-
 
       - name: Pod Install
-        run: pod install
+        run: pod install --repo-update
         working-directory: ./ios
 
       - name: Bundle iOS JS


### PR DESCRIPTION
* Android: increase file descriptors, fixes file watcher limit error:

  ```
  Error: ENOSPC: System limit for number of file watchers reached
  ```

* iOS compress 2 steps into one