### PR TITLE
Add jest config to .eslintrc.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,6 @@
 {
   "root": true,
-  "extends": [
-    "eslint:recommended",
-    "plugin:react/recommended"
-  ],
+  "extends": ["eslint:recommended", "plugin:react/recommended"],
   "parser": "babel-eslint",
   "plugins": [
     "react",
@@ -22,17 +19,19 @@
     "commonjs": true,
     "es6": true,
     "react-native/react-native": true,
-    "node": true
+    "node": true,
+    "jest": true
   },
   "settings": {
     "react": {
       "version": "detect"
     }
   },
-  "rules": { // 0 is for off, 1 is for warning, 2 is for error
+  "rules": {
+    // 0 is for off, 1 is for warning, 2 is for error
     "eol-last": 2, // Require file to end with single newline
     "no-constant-condition": 2, // Disallow use of constant expressions in conditions
-    "no-dupe-keys": 2, // Disallow Duplicate Keys 
+    "no-dupe-keys": 2, // Disallow Duplicate Keys
     "no-empty": 2, // Disallow Empty Block Statements
     "no-extra-boolean-cast": 2, // Disallow Extra Boolean Casts
     "no-prototype-builtins": 2, // Disallow use of Object.prototypes builtins directly
@@ -43,10 +42,7 @@
     "no-useless-escape": 2, // Disallow unnecessary escape usage
     "no-console": 0, // disallow the use of console
     "no-var": 2, // require let or const instead of var
-    "strict": [
-      2,
-      "global"
-    ], // require or disallow strict mode directives
+    "strict": [2, "global"], // require or disallow strict mode directives
     "react-native/no-color-literals": 1, // Detect StyleSheet rules and inline styles containing color literals instead of variables
     "react-native/no-inline-styles": 0, // For keeping styles away from the logic, we can switch it to 1 in future
     "react-native/no-raw-text": 1, // This is to make sure everything is translated in the app


### PR DESCRIPTION
Signed-off-by: Patrick Erichsen <patrick.a.erichsen@gmail.com>

Added `"jest": true` to our ESLint env config.

Without this, my IDE was complaining that it could not find definitions for any Jest methods (e.g. `describe()`, `expect()`, etc.).

Additional formatting that was automatically applied based on our linting config.