### PR TITLE
replace npm global install and npm install commands with yarn in dev setup scripts

### DIFF
--- a/dev_setup.bat
+++ b/dev_setup.bat
@@ -83,12 +83,22 @@ pause > nul
 call RefreshEnv.cmd
 cls
 echo.
+echo Yarn will now be installed.
+echo Press SPACE to continue.
+pause > nul
+echo.
+cmd /c choco install yarn
+echo.
+echo Press SPACE to continue.
+pause > nul
+cls
+echo.
 echo React Native will now be installed.
 echo Press SPACE to continue.
 pause > nul
 echo.
-cmd /c npm install -g react-native-cli
-cmd /c npm install
+cmd /c yarn global add react-native-cli
+cmd /c yarn
 echo.
 echo.
 echo Press SPACE to continue.

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -202,10 +202,17 @@ if [[ "$OSTYPE" == "darwin"* ]] ; then
 fi
 
 
+if ! found_exe yarn ; then
+    echo "${BLUE}Installing Yarn package manager${RESET}"
+    brew install yarn
+    yarn
+    echo "${GREEN}Yarn installed!${RESET}"
+fi
+
 if ! found_exe react-native ; then
     echo "${BLUE}Installing React Native tool...${RESET}"
-    sudo npm install -g react-native-cli
-    npm install
+    yarn global add react-native-cli
+    yarn
     echo "${GREEN}React Native tools installed!${RESET}"
 fi
 


### PR DESCRIPTION
Fixes #429 

Since the project is using yarn, provision it in the development setup scripts.