### PR TITLE
Adjust text vertical centering around pulse

### DIFF
--- a/app/views/LocationTracking.js
+++ b/app/views/LocationTracking.js
@@ -420,14 +420,21 @@ class LocationTracking extends Component {
           translucent={true}
         />
         {this.getPulseIfNeeded()}
+
         <View style={styles.mainContainer}>
-          <View style={styles.contentContainer}>
-            {this.getMainText()}
+          <View style={styles.contentAbovePulse}>
+            {this.state.currentState === StateEnum.AT_RISK &&
+              this.getMainText()}
             <Text style={styles.subsubheaderText}>{this.getSubSubText()}</Text>
+          </View>
+          <View style={styles.contentBelowPulse}>
+            {this.state.currentState !== StateEnum.AT_RISK &&
+              this.getMainText()}
             <Text style={styles.subheaderText}>{this.getSubText()}</Text>
             {this.getCTAIfNeeded()}
           </View>
         </View>
+
         <View>
           <TouchableOpacity
             onPress={this.getMayoInfoPressed.bind(this)}
@@ -459,21 +466,40 @@ class LocationTracking extends Component {
   }
 }
 
+const PULSE_GAP = 80;
+
 const styles = StyleSheet.create({
   backgroundImage: {
     width: '100%',
     height: '100%',
     resizeMode: 'cover',
     flex: 1,
+    justifyContent: 'flex-end',
   },
   mainContainer: {
-    top: '50%',
-    flex: 1,
+    position: 'absolute',
+    // resizeMode: 'contain',
+    // aligns the center of the main container with center of pulse
+    // so that two `flex: 1` views will be have a reasonable chance at natural
+    // flex flow for above and below the pulse.
+    top: '-10%',
+    left: 0,
+    right: 0,
+    height: '100%',
+    paddingHorizontal: '12%',
+    paddingBottom: 12,
   },
-  contentContainer: {
-    width: width * 0.65,
+  contentAbovePulse: {
     flex: 1,
-    alignSelf: 'center',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    paddingBottom: PULSE_GAP / 2,
+  },
+  contentBelowPulse: {
+    flex: 1,
+    justifyContent: 'flex-start',
+    alignItems: 'center',
+    paddingTop: PULSE_GAP,
   },
   settingsContainer: {
     position: 'absolute',
@@ -483,11 +509,12 @@ const styles = StyleSheet.create({
     alignSelf: 'flex-end',
   },
   buttonContainer: {
-    top: '9%',
+    top: 24,
   },
   pulseContainer: {
     position: 'absolute',
     resizeMode: 'contain',
+    height: '100%',
     top: '-13%',
     left: 0,
     right: 0,
@@ -496,8 +523,7 @@ const styles = StyleSheet.create({
   mainTextAbove: {
     textAlign: 'center',
     lineHeight: 34,
-    marginTop: -210,
-    marginBottom: 125,
+    marginBottom: 24,
     color: Colors.WHITE,
     fontSize: 28,
     fontFamily: fontFamily.primaryMedium,
@@ -508,9 +534,10 @@ const styles = StyleSheet.create({
     color: Colors.WHITE,
     fontSize: 26,
     fontFamily: fontFamily.primaryMedium,
+    marginBottom: 24,
   },
   subheaderText: {
-    marginTop: 120,
+    marginBottom: 24,
     textAlign: 'center',
     lineHeight: 24.5,
     color: Colors.WHITE,
@@ -518,13 +545,12 @@ const styles = StyleSheet.create({
     fontFamily: fontFamily.primaryRegular,
   },
   subsubheaderText: {
-    marginTop: -115,
     textAlign: 'center',
     lineHeight: 24.5,
     color: Colors.WHITE,
     fontSize: 16,
     fontFamily: fontFamily.primaryLight,
-    marginBottom: '8%',
+    marginBottom: 24,
   },
   mayoInfoRow: {
     flexDirection: 'row',


### PR DESCRIPTION
Follow up to some text adjustment in #436

The way pulse icon and text are laid out probably needs an overhaul, but this tried to adress things via creating a container that centers on the pulse, then creates two `flex: 1;` containers which will intersect the pulse (its not perfect on all screens) .. using this, we can produce containers above and below with flexing to `end` and `start` respectively:
 
<img width="477" alt="Screen Shot 2020-04-11 at 4 47 57 PM" src="https://user-images.githubusercontent.com/702990/79057515-31cf9080-7c17-11ea-9055-1894f5dc1a6d.png">

It gives a somewhat predictable flow "around" the pulse. This is about all I could manage without rethinking it from the ground up.

Screens to come