### PR TITLE
Fix typo "procceed" to "proceed"

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -8,7 +8,7 @@
     "authorities_no_sources": "No data source yet",
     "authorities_removal_alert_cancel": "Cancel",
     "authorities_removal_alert_desc": "Are you sure you want to remove this authority data source?",
-    "authorities_removal_alert_proceed": "Procceed",
+    "authorities_removal_alert_proceed": "Proceed",
     "authorities_removal_alert_title": "Remove authority",
     "authorities_title": "Trusted Sources",
     "choose_provider_subtitle": "To be informed of exposures you will need to subscribe to a health authority.",


### PR DESCRIPTION
Simple typo in the Healthcare Authorities dialogs.

 ### Fixed Issues ###
This resolved issue #464

 ### Localization Notes  ###
This probably won't impact any localization -- I'm assuming they understand
the meaning even with the typo.