### PR TITLE
Configure Android to use singleTask launchMode

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -38,7 +38,8 @@
         android:screenOrientation="portrait"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
         android:windowSoftInputMode="adjustResize"
-        android:exported="true">
+        android:exported="true"
+        android:launchMode="singleTask">
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
         <meta-data  android:name="com.dieam.reactnativepushnotification.notification_channel_name"


### PR DESCRIPTION
## Description

Change discussed in #500 

## How to test

With each notification click, instead of a new instance pushed on top of the application stack, it will open the existing activity.
