### PR TITLE
Fix usage of URL from a Healthcare Authority

### DIFF
--- a/app/views/News.js
+++ b/app/views/News.js
@@ -15,9 +15,9 @@ import languages from './../locales/languages';
 import NavigationBarWrapper from '../components/NavigationBarWrapper';
 import colors from '../constants/colors';
 import Colors from '../constants/colors';
-import { AUTHORITY_NEWS } from '../constants/storage';
 // import { Colors } from 'react-native/Libraries/NewAppScreen';
 import fontFamily from '../constants/fonts';
+import { AUTHORITY_NEWS } from '../constants/storage';
 import { GetStoreData } from '../helpers/General';
 
 const width = Dimensions.get('window').width;
@@ -28,7 +28,7 @@ class NewsScreen extends Component {
     super(props);
     let default_news = {
       name: languages.t('label.default_news_site_name'),
-      url: languages.t('label.default_news_site_url'),
+      news_url: languages.t('label.default_news_site_url'),
     };
     this.state = {
       visible: true,
@@ -62,7 +62,7 @@ class NewsScreen extends Component {
         </View>
         <WebView
           source={{
-            uri: item.item.url,
+            uri: item.item.news_url,
           }}
           containerStyle={{
             borderBottomLeftRadius: 12,

--- a/app/views/__tests__/__snapshots__/News.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/News.spec.js.snap
@@ -178,7 +178,7 @@ exports[`renders correctly 1`] = `
               Array [
                 Object {
                   "name": "Safe Paths News",
-                  "url": "https://covidsafepaths.org/in-app-news",
+                  "news_url": "https://covidsafepaths.org/in-app-news",
                 },
               ]
             }


### PR DESCRIPTION
The webview was using the wrong name for the webview ("url" instead of
"news_url").

 ### Testing Notes ###
The "Example Authority" was not showing a webpage.  It does now.