### PR TITLE
Bump the versionCodes to what they should have been for 0.9.4

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -132,7 +132,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         multiDexEnabled true
-        versionCode 21
+        versionCode 22
         versionName "0.9.4"
     }
     splits {

--- a/ios/COVIDSafePaths/Info.plist
+++ b/ios/COVIDSafePaths/Info.plist
@@ -25,7 +25,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>21</string>
+	<string>22</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true />
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
## Description

Another reason the way we branched the RC build was annoying ... the version bump got out of sync for the 0.9.4 release.  This bumps us forward 1 to account for the 0.9.3 build.

