### PR TITLE
FIX: add covid-safe-paths to the end of the git clone command example to make it correct

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,10 @@ We welcome participation in an open project. We want to make it as easy as possi
 
 cd ~ # get to your home directory or where ever you want to go
 
-git clone https://github.com/YOURACCOUNT/
+git clone https://github.com/YOURACCOUNT/covid-safe-paths
+
+# change into the newly created directory
+cd covid-safe-paths
 
 # set upstream against COVID Safe Paths repository
 git remote add upstream https://github.com/tripleblindmarket/covid-safe-paths.git


### PR DESCRIPTION
## Description

Updates an example line in the CONTRIBUTING.md file to include the name of the repository
covid-safe-paths so that the command works correctly.

Added in an explicit change directory to the newly created directory 
cd covid-safe paths

so that the next command (adding upstream)  would work properly.

## How to test
Follow the directions to set up a new fork on your local machine and verify that the new commands work.   [I tested on Linux Ubuntu 18.04 ]
