### PR TITLE
Make settings test independent of locales

### DIFF
--- a/app/locales/languages.js
+++ b/app/locales/languages.js
@@ -85,7 +85,7 @@ i18next.init({
     id: { label: 'Indonesia', translation: id },
     it: { label: 'Italiano', translation: it },
     ml: { label: 'മലയാളം', translation: ml },
-    ro: { label: 'test', translation: ro },
+    ro: { label: 'Română', translation: ro },
     ru: { label: 'Русский', translation: ru },
     sk: { label: 'Slovak', translation: sk },
     vi: { label: 'Vietnamese', translation: vi },

--- a/app/locales/languages.js
+++ b/app/locales/languages.js
@@ -85,7 +85,7 @@ i18next.init({
     id: { label: 'Indonesia', translation: id },
     it: { label: 'Italiano', translation: it },
     ml: { label: 'മലയാളം', translation: ml },
-    ro: { label: 'Română', translation: ro },
+    ro: { label: 'test', translation: ro },
     ru: { label: 'Русский', translation: ru },
     sk: { label: 'Slovak', translation: sk },
     vi: { label: 'Vietnamese', translation: vi },

--- a/app/views/__tests__/Settings.spec.js
+++ b/app/views/__tests__/Settings.spec.js
@@ -12,8 +12,19 @@ jest.mock('../../helpers/General', () => {
   };
 });
 
+let BACKUP_LOCALE_LIST;
+
 beforeEach(() => {
   jest.spyOn(languages, 'findUserLang').mockResolvedValue('en');
+  BACKUP_LOCALE_LIST = languages.LOCALE_LIST;
+  languages.LOCALE_LIST = [
+    { label: 'English', value: 'en' },
+    { label: 'Test', value: 'test' },
+  ];
+});
+
+afterEach(() => {
+  languages.LOCALE_LIST = BACKUP_LOCALE_LIST;
 });
 
 jest.useFakeTimers();

--- a/app/views/__tests__/__snapshots__/Settings.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Settings.spec.js.snap
@@ -321,59 +321,9 @@ exports[`renders correctly 1`] = `
                                 "value": "en",
                               },
                               Object {
-                                "label": "Español",
+                                "label": "Test",
                                 "textColor": undefined,
-                                "value": "es",
-                              },
-                              Object {
-                                "label": "Français",
-                                "textColor": undefined,
-                                "value": "fr",
-                              },
-                              Object {
-                                "label": "Kreyòl ayisyen",
-                                "textColor": undefined,
-                                "value": "ht",
-                              },
-                              Object {
-                                "label": "Indonesia",
-                                "textColor": undefined,
-                                "value": "id",
-                              },
-                              Object {
-                                "label": "Italiano",
-                                "textColor": undefined,
-                                "value": "it",
-                              },
-                              Object {
-                                "label": "മലയാളം",
-                                "textColor": undefined,
-                                "value": "ml",
-                              },
-                              Object {
-                                "label": "Română",
-                                "textColor": undefined,
-                                "value": "ro",
-                              },
-                              Object {
-                                "label": "Русский",
-                                "textColor": undefined,
-                                "value": "ru",
-                              },
-                              Object {
-                                "label": "Slovak",
-                                "textColor": undefined,
-                                "value": "sk",
-                              },
-                              Object {
-                                "label": "Vietnamese",
-                                "textColor": undefined,
-                                "value": "vi",
-                              },
-                              Object {
-                                "label": "繁體中文",
-                                "textColor": undefined,
-                                "value": "zh_Hant",
+                                "value": "test",
                               },
                             ]
                           }


### PR DESCRIPTION
`Settings.js` test lists out all locales, so any addition to locales requires an update to the snapshot... this makes the test independent of real locales.
