### PR TITLE
Issue 564 - change message ( fixed english only )

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -64,6 +64,8 @@
     "location_disabled_title": "Location Tracking Was Disabled",
     "location_enabled_message": "COVID Safe Paths is securely storing your GPS coordinates once every five minutes on this device.",
     "location_enabled_title": "COVID Safe Paths Enabled",
+    "location_stopped_message": "Stopped",
+    "location_stopped_at_user_request_message": "Stopped at user request",
     "maps_import_button_text": "Import past locations",
     "maps_import_disclaimer": "Safe Paths has no affiliation with Google and never shares your data.",
     "maps_import_text": "To see if you encountered someone with COVID-19 prior to downloading this app, you can import your personal location history.",

--- a/app/services/LocationService.js
+++ b/app/services/LocationService.js
@@ -366,9 +366,22 @@ export default class LocationServices {
 
   static stop() {
     // unregister all event listeners
-    PushNotification.localNotification({
-      title: languages.t('label.location_disabled_title'),
-      message: languages.t('label.location_disabled_message'),
+    BackgroundGeolocation.checkStatus(({ locationServicesEnabled }) => {
+      if (!locationServicesEnabled) {
+        PushNotification.localNotification({
+          id: LOCATION_DISABLED_NOTIFICATION,
+          title: languages.t('label.location_disabled_title'),
+          message: languages.t('label.location_stopped_message'),
+        });
+      } else {
+        PushNotification.localNotification({
+          id: LOCATION_DISABLED_NOTIFICATION,
+          title: languages.t('label.location_disabled_title'),
+          message: languages.t(
+            'label.location_stopped_at_user_request_message',
+          ),
+        });
+      }
     });
     BackgroundGeolocation.removeAllListeners();
     BackgroundGeolocation.stop();


### PR DESCRIPTION
## Description

resolves issue 564. the message was confusing so was changed (in the english resourse only ) to the suggested stopped when location services are disabled or stopped at user request
## How to test
1 go to settings,
click on stop logging text or icon, 
see message appears.  it should now read
Location Tracking was disabled
Stopped at user request.
2 go to settings
turn off location services from OS.
click on stop logging text or icon
see message appears.  it should now read
Location Tracking was disabled
Stopped.

Still todo other languages (please advise!)
(In another locale the english text will appear until the translation is present I think)
