### PR TITLE
Set returnEmptyString to false

### DIFF
--- a/app/locales/languages.js
+++ b/app/locales/languages.js
@@ -80,6 +80,7 @@ i18next.init({
   },
   lng: 'en', // 'en' | 'es',
   fallbackLng: 'en', // If language detector fails
+  returnEmptyString: false,
   resources: {
     en: { label: 'English', translation: en },
     es: { label: 'Español', translation: es },


### PR DESCRIPTION
## Description

PR sets i18next's returnEmptyString flag to false for avoid app crashes on passing empty strings. Resolves #593.

## How to test

Choose Nederalnds language on onboarding or in settings, open settings.
