### PR TITLE
Stop lint-diff on regular pushes to develop, fails always

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,11 +1,6 @@
 name: Lint
 
 on:
-  push:
-    branches:
-      - develop
-      - release-candidate
-      - master
   pull_request:
     branches:
       - develop


### PR DESCRIPTION
## Description

this should clean up the commit checks on develop