### PR TITLE
Fix languages specific for history page

### DIFF
--- a/app/views/ExposureHistory/ExposureCalendarView.js
+++ b/app/views/ExposureHistory/ExposureCalendarView.js
@@ -73,6 +73,7 @@ const LegendRow = styled.View`
   flex-direction: row;
   justify-content: center;
   margin-top: 16px;
+  flex-wrap: wrap;
 `;
 
 const LegendItem = ({ children, riskLevel }) => {


### PR DESCRIPTION
## Description

Fix languages specific for history page #621 

## How to test

From home tap the right top setting button
Tap on Exposure history
Affected languages:

- Polish
- Italian
- Indonesian
- Slovak
