### PR TITLE
Fix settings locale override storage

### DIFF
--- a/app/locales/languages.js
+++ b/app/locales/languages.js
@@ -66,9 +66,6 @@ export function useLanguageDirection() {
 
 export async function setUserLocaleOverride(locale) {
   await setLocale(locale);
-  if (locale === supportedDeviceLanguageOrEnglish()) {
-    locale = undefined;
-  }
   await SetStoreData(LANG_OVERRIDE, locale);
 }
 


### PR DESCRIPTION
Fixes a regression in language setting, sometimes the language override selected by the user is not saved.

## How to test

Change the language in the settings screen and then close the app, reopen, check that it is stuck to the new language.
