### PR TITLE
Revert "Fix missing settings icon on iOS 12.0.x (#643)"

### DIFF
--- a/app/assets/svgs/backArrow.js
+++ b/app/assets/svgs/backArrow.js
@@ -1,6 +1,6 @@
 export default `<?xml version="1.0" encoding="UTF-8"?>
 <svg width="25" height="25" viewBox="0 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<rect width="25" height="25" fill="url(#pattern0)" stroke="white" strokeWidth=".1"/>
+<rect width="25" height="25" fill="url(#pattern0)"/>
 <defs>
 <pattern id="pattern0" patternContentUnits="objectBoundingBox" width="1" height="1">
 <use xlink:href="#image0" transform="scale(0.00333333)"/>

--- a/app/assets/svgs/settingsGear.js
+++ b/app/assets/svgs/settingsGear.js
@@ -1,5 +1,5 @@
 export default `<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-<rect width="28" height="28" fill="url(#pattern0)" stroke="white" strokeWidth=".1"/>
+<rect width="28" height="28" fill="url(#pattern0)"/>
 <defs>
 <pattern id="pattern0" patternContentUnits="objectBoundingBox" width="1" height="1">
 <use xlink:href="#image0" transform="scale(0.00333333)"/>

--- a/app/views/__tests__/__snapshots__/Import.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Import.spec.js.snap
@@ -65,7 +65,7 @@ Array [
           }
           xml="<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <svg width=\\"25\\" height=\\"25\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\">
-<rect width=\\"25\\" height=\\"25\\" fill=\\"url(#pattern0)\\" stroke=\\"white\\" strokeWidth=\\".1\\"/>
+<rect width=\\"25\\" height=\\"25\\" fill=\\"url(#pattern0)\\"/>
 <defs>
 <pattern id=\\"pattern0\\" patternContentUnits=\\"objectBoundingBox\\" width=\\"1\\" height=\\"1\\">
 <use xlink:href=\\"#image0\\" transform=\\"scale(0.00333333)\\"/>

--- a/app/views/__tests__/__snapshots__/Licenses.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Licenses.spec.js.snap
@@ -66,7 +66,7 @@ exports[`renders correctly 1`] = `
           }
           xml="<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <svg width=\\"25\\" height=\\"25\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\">
-<rect width=\\"25\\" height=\\"25\\" fill=\\"url(#pattern0)\\" stroke=\\"white\\" strokeWidth=\\".1\\"/>
+<rect width=\\"25\\" height=\\"25\\" fill=\\"url(#pattern0)\\"/>
 <defs>
 <pattern id=\\"pattern0\\" patternContentUnits=\\"objectBoundingBox\\" width=\\"1\\" height=\\"1\\">
 <use xlink:href=\\"#image0\\" transform=\\"scale(0.00333333)\\"/>

--- a/app/views/__tests__/__snapshots__/News.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/News.spec.js.snap
@@ -93,7 +93,7 @@ exports[`renders correctly 1`] = `
             }
             xml="<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <svg width=\\"25\\" height=\\"25\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\">
-<rect width=\\"25\\" height=\\"25\\" fill=\\"url(#pattern0)\\" stroke=\\"white\\" strokeWidth=\\".1\\"/>
+<rect width=\\"25\\" height=\\"25\\" fill=\\"url(#pattern0)\\"/>
 <defs>
 <pattern id=\\"pattern0\\" patternContentUnits=\\"objectBoundingBox\\" width=\\"1\\" height=\\"1\\">
 <use xlink:href=\\"#image0\\" transform=\\"scale(0.00333333)\\"/>

--- a/app/views/__tests__/__snapshots__/Settings.spec.js.snap
+++ b/app/views/__tests__/__snapshots__/Settings.spec.js.snap
@@ -66,7 +66,7 @@ exports[`renders correctly 1`] = `
           }
           xml="<?xml version=\\"1.0\\" encoding=\\"UTF-8\\"?>
 <svg width=\\"25\\" height=\\"25\\" viewBox=\\"0 0 25 25\\" fill=\\"none\\" xmlns=\\"http://www.w3.org/2000/svg\\" xmlns:xlink=\\"http://www.w3.org/1999/xlink\\">
-<rect width=\\"25\\" height=\\"25\\" fill=\\"url(#pattern0)\\" stroke=\\"white\\" strokeWidth=\\".1\\"/>
+<rect width=\\"25\\" height=\\"25\\" fill=\\"url(#pattern0)\\"/>
 <defs>
 <pattern id=\\"pattern0\\" patternContentUnits=\\"objectBoundingBox\\" width=\\"1\\" height=\\"1\\">
 <use xlink:href=\\"#image0\\" transform=\\"scale(0.00333333)\\"/>


### PR DESCRIPTION
This reverts commit 73a33d13c6b616e186dfbec4b21e6384b63930c5 (Reverts #643)

This fix caused hairlines around the icons on android:

<img width="307" alt="Screen Shot 2020-04-23 at 11 54 59 AM" src="https://user-images.githubusercontent.com/702990/80138170-4423c580-8559-11ea-83d1-5bed6e15bf79.png">
<img width="310" alt="Screen Shot 2020-04-23 at 11 54 51 AM" src="https://user-images.githubusercontent.com/702990/80138207-50a81e00-8559-11ea-9158-ea862a62fc22.png">


Fixed:

<img width="306" alt="Screen Shot 2020-04-23 at 11 55 51 AM" src="https://user-images.githubusercontent.com/702990/80138265-63baee00-8559-11ea-9b07-2554d778d604.png">


## How to test

Check there is no hairline around icons
