### PR TITLE
Disable google import on release builds

### DIFF
--- a/app/views/Settings.js
+++ b/app/views/Settings.js
@@ -128,9 +128,11 @@ export const SettingsScreen = ({ navigation }) => {
           />
         </Section>
 
-        <Section>
-          <GoogleMapsImport navigation={navigation} />
-        </Section>
+        {__DEV__ && (
+          <Section>
+            <GoogleMapsImport navigation={navigation} />
+          </Section>
+        )}
 
         <Section last>
           <Item


### PR DESCRIPTION
Disable Google import in release builds.

## How to test

Verify in non __DEV__ mode that the block is gone:

<img width="307" alt="Screen Shot 2020-04-23 at 3 12 57 PM" src="https://user-images.githubusercontent.com/702990/80154874-498f0900-8575-11ea-9fa0-e09b5a6c16d8.png">

