### PR TITLE
Add version check service

### DIFF
--- a/App.js
+++ b/App.js
@@ -12,10 +12,12 @@ import SplashScreen from 'react-native-splash-screen';
 
 import { Theme } from './app/constants/themes';
 import Entry from './app/Entry';
+import VersionCheckService from './app/services/VersionCheckService';
 
 const App = () => {
   useEffect(() => {
     SplashScreen.hide();
+    VersionCheckService.start();
   }, []);
 
   return (

--- a/app/Util.js
+++ b/app/Util.js
@@ -13,6 +13,11 @@ export function nowStr() {
   return dayjs().format('H:mm');
 }
 
+export const isVersionGreater = (source, target) =>
+  source
+    .split('.')
+    .some((val, index) => parseInt(val) > parseInt(target.split('.')[index]));
+
 export default {
   isPlatformiOS,
   isPlatformAndroid,

--- a/app/constants/urls.js
+++ b/app/constants/urls.js
@@ -1,0 +1,6 @@
+// need to get actual links to stores
+export const APPSTORE_URL = 'itms-apps://itunes.apple.com/us/app/id1501903733';
+export const PLAYSTORE_URL = 'market://details?id=edu.mit.privatekit';
+// placeholder json for testing, to be changed
+export const VERSION_URL =
+  'https://raw.githubusercontent.com/Fatkhi/covid-safe-paths/releases/versions.json';

--- a/app/constants/urls.js
+++ b/app/constants/urls.js
@@ -1,6 +1,6 @@
 // need to get actual links to stores
-export const APPSTORE_URL = 'itms-apps://itunes.apple.com/us/app/id1501903733';
-export const PLAYSTORE_URL = 'market://details?id=edu.mit.privatekit';
+export const APPSTORE_URL = 'itms-apps://itunes.apple.com/us/app/id1508266966';
+export const PLAYSTORE_URL = 'market://details?id=org.pathcheck.covidsafepaths';
 // placeholder json for testing, to be changed
 export const VERSION_URL =
   'https://raw.githubusercontent.com/Fatkhi/covid-safe-paths/releases/versions.json';

--- a/app/constants/urls.js
+++ b/app/constants/urls.js
@@ -1,6 +1,0 @@
-// need to get actual links to stores
-export const APPSTORE_URL = 'itms-apps://itunes.apple.com/us/app/id1508266966';
-export const PLAYSTORE_URL = 'market://details?id=org.pathcheck.covidsafepaths';
-// placeholder json for testing, to be changed
-export const VERSION_URL =
-  'https://raw.githubusercontent.com/Fatkhi/covid-safe-paths/releases/versions.json';

--- a/app/constants/versionCheck.js
+++ b/app/constants/versionCheck.js
@@ -1,6 +1,6 @@
 export const APPSTORE_URL = 'itms-apps://itunes.apple.com/us/app/id1508266966';
 export const PLAYSTORE_URL = 'market://details?id=org.pathcheck.covidsafepaths';
 export const VERSION_URL =
-  'https://raw.githack.com/Fatkhi/covid-safe-paths/versions-yaml/versions.yaml';
+  'https://rawcdn.githack.com/tripleblindmarket/covid-safe-paths/0008e269c355e14bb216bb6e69cf4b89e25012b2/versions.yaml';
 export const YAML_MANDATORY_VERSION_KEY = 'mandatory update for less than';
 export const YAML_LATEST_VERSION_KEY = 'latest version';

--- a/app/constants/versionCheck.js
+++ b/app/constants/versionCheck.js
@@ -1,0 +1,6 @@
+export const APPSTORE_URL = 'itms-apps://itunes.apple.com/us/app/id1508266966';
+export const PLAYSTORE_URL = 'market://details?id=org.pathcheck.covidsafepaths';
+export const VERSION_URL =
+  'https://raw.githack.com/Fatkhi/covid-safe-paths/versions-yaml/versions.yaml';
+export const YAML_MANDATORY_VERSION_KEY = 'mandatory update for less than';
+export const YAML_LATEST_VERSION_KEY = 'latest version';

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -109,5 +109,13 @@
     "what_does_this_mean": "What does this mean?",
     "what_if_no_symptoms_para": "If you have no symptoms but still would like to be tested you can go to your nearest testing site.\n\nIndividuals who don't exhibit symptoms can sometimes still carry the infection and infect others. Being careful about social distancing and coming in contact with large groups or at risk individuals (the elderly, those with significant other medical issues) is important to manage both your risk and the risk to others.",
     "what_if_no_symptoms": "What if I’m not showing symptoms?"
+  },
+  "version_update": {
+    "push_notification_title": "Application is outdate",
+    "push_notification_message": "Please update your application",
+    "alert_label": "COVID Safe Paths is outdated",
+    "alert_sublabel": "Update to a new version?",
+    "update": "Update",
+    "later": "Later"
   }
 }

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -111,7 +111,7 @@
     "what_if_no_symptoms": "What if I’m not showing symptoms?"
   },
   "version_update": {
-    "push_notification_title": "Application is outdate",
+    "push_notification_title": "Application is outdated",
     "push_notification_message": "Please update your application",
     "alert_label": "COVID Safe Paths is outdated",
     "alert_sublabel": "Update to a new version?",

--- a/app/services/VersionCheckService.js
+++ b/app/services/VersionCheckService.js
@@ -1,0 +1,96 @@
+import { Alert, Linking } from 'react-native';
+import BackgroundTimer from 'react-native-background-timer';
+import PushNotification from 'react-native-push-notification';
+
+import { version as currentVersion } from '../../package.json';
+import { APPSTORE_URL, PLAYSTORE_URL, VERSION_URL } from '../constants/urls';
+import languages from '../locales/languages';
+import { isPlatformiOS, isVersionGreater } from '../Util';
+
+const POLL_INTERVAL = 60 * 60 * 1000; //one hour
+
+const updateLink = isPlatformiOS() ? APPSTORE_URL : PLAYSTORE_URL;
+let isPollStarted = false;
+//make sure we show only one notification
+let notificationShown = false;
+
+export default class VersionCheckService {
+  static start() {
+    if (!isPollStarted) {
+      this.checkUpdate();
+      // currenly BackgroundTimer is not used anywhere else.
+      // But this thing should be called only once, otherwise it behaves not as expected.
+      // It worths making a separate service.
+      BackgroundTimer.runBackgroundTimer(
+        () => this.checkUpdate(),
+        POLL_INTERVAL,
+      );
+      isPollStarted = true;
+    }
+  }
+
+  static stop() {
+    BackgroundTimer.stopBackgroundTimer();
+  }
+
+  static async checkUpdate() {
+    if (notificationShown) return;
+    let mandatoryVersion, latestVersion;
+    try {
+      const response = await fetch(VERSION_URL);
+      const { mandatory_version, version } = await response.json();
+      mandatoryVersion = mandatory_version;
+      latestVersion = version;
+    } catch (err) {
+      console.log(err);
+      return;
+    }
+
+    if (!isVersionGreater(latestVersion, currentVersion)) return;
+
+    const isMandatoryUpdate = isVersionGreater(
+      mandatoryVersion,
+      currentVersion,
+    );
+    this.showNotifications(isMandatoryUpdate);
+  }
+
+  static showNotifications(isMandatoryUpdate) {
+    const updateOption = {
+      text: languages.t('version_update.update'),
+      onPress: () => {
+        notificationShown = false;
+        Linking.canOpenURL(updateLink).then(
+          supported => supported && Linking.openURL(updateLink),
+          err => console.log(err),
+        );
+      },
+    };
+    const laterOption = {
+      text: languages.t('version_update.later'),
+      onPress: () => {
+        notificationShown = false;
+        console.log('User does not want to update the app');
+      },
+      style: 'cancel',
+    };
+
+    const alertOptions = [updateOption];
+
+    if (isMandatoryUpdate) {
+      PushNotification.localNotification({
+        title: languages.t('version_update.push_notification_title'),
+        message: languages.t('version_update.push_notification_message'),
+      });
+    } else {
+      alertOptions.push(laterOption);
+    }
+
+    notificationShown = true;
+    Alert.alert(
+      languages.t('version_update.alert_label'),
+      languages.t('version_update.alert_sublabel'),
+      alertOptions,
+    );
+  }
+}

--- a/app/services/VersionCheckService.js
+++ b/app/services/VersionCheckService.js
@@ -1,13 +1,20 @@
+import Yaml from 'js-yaml';
 import { Alert, Linking } from 'react-native';
 import BackgroundTimer from 'react-native-background-timer';
 import PushNotification from 'react-native-push-notification';
 
 import { version as currentVersion } from '../../package.json';
-import { APPSTORE_URL, PLAYSTORE_URL, VERSION_URL } from '../constants/urls';
+import {
+  APPSTORE_URL,
+  PLAYSTORE_URL,
+  VERSION_URL,
+  YAML_LATEST_VERSION_KEY,
+  YAML_MANDATORY_VERSION_KEY,
+} from '../constants/versionCheck';
 import languages from '../locales/languages';
 import { isPlatformiOS, isVersionGreater } from '../Util';
 
-const POLL_INTERVAL = 60 * 60 * 1000; //one hour
+const POLL_INTERVAL = 24 * 60 * 60 * 1000; //one day
 
 const updateLink = isPlatformiOS() ? APPSTORE_URL : PLAYSTORE_URL;
 let isPollStarted = false;
@@ -38,9 +45,10 @@ export default class VersionCheckService {
     let mandatoryVersion, latestVersion;
     try {
       const response = await fetch(VERSION_URL);
-      const { mandatory_version, version } = await response.json();
-      mandatoryVersion = mandatory_version;
-      latestVersion = version;
+      const responseText = await response.text();
+      const parsedFile = Yaml.safeLoad(responseText);
+      mandatoryVersion = parsedFile[YAML_MANDATORY_VERSION_KEY];
+      latestVersion = parsedFile[YAML_LATEST_VERSION_KEY];
     } catch (err) {
       console.log(err);
       return;

--- a/ios/COVIDSafePaths/Info.plist
+++ b/ios/COVIDSafePaths/Info.plist
@@ -2,6 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>itms-apps</string>
+	</array>
+	<key>LSApplicationCategoryType</key>
+	<string></string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>com.transistorsoft.fetch</string>

--- a/jestSetupFile.js
+++ b/jestSetupFile.js
@@ -17,7 +17,10 @@ jest.mock(
 );
 jest.mock('react-native-share', () => 'Share');
 jest.mock('rn-fetch-blob', () => 'Blob');
-jest.mock('react-native-background-timer', () => 'BackgroundTimer');
+jest.mock('react-native-background-timer', () => ({
+  runBackgroundTimer: () => {},
+  stopBackgroundTimer: () => {},
+}));
 jest.mock('react-native-popup-menu', () => ({
   Menu: 'Menu',
   MenuProvider: 'MenuProvider',


### PR DESCRIPTION
## Description

Adds upgrade notification functionality.

Fixes https://github.com/tripleblindmarket/covid-safe-paths/issues/652, https://github.com/tripleblindmarket/covid-safe-paths/issues/40

Currently, version checker relies on [static version file](https://github.com/Fatkhi/covid-safe-paths/blob/releases/versions.json)

It makes fetch requests as soon as a user opens the app and then every hour in the background. If the app's current version (from package.json) is less than `version` specified in json file, a simple alert will appear with an ability to delay the upgrade:

![Simulator Screen Shot - iPhone 11 - 2020-04-23 at 16 14 33](https://user-images.githubusercontent.com/9149211/80158574-ae4e6180-857d-11ea-8057-7750ea2b80ef.png)

If the app's current version (from package.json) is less than `mandatory_version` specified in json file, alert without the ability to delay + push notification will appear:

![Simulator Screen Shot - iPhone 11 - 2020-04-23 at 16 16 16](https://user-images.githubusercontent.com/9149211/80158639-d6d65b80-857d-11ea-8a17-5cb291bedfb7.png)

The above is useful for critical updates.

### TODO:

- [ ] Add translations for new texts: Push title, message, alert label, sublabel, later and update buttons
- [x] Add correct links to AppStore and Playstore 
- [x] Change location of `versions.json` file, or switch to other solution (need to discuss)
- [x] Fix typo in `Application is outdate` :)

## How to test

Change your `package.json` to 
- 1.0.0 to see no notifications
- 0.9.4 to see only gentle alert
- 0.9.1 for mandatory update

<!-- Description of how to validate or test this PR -->
