### PR TITLE
Temporarily filter out extra languages in release mode

### DIFF
--- a/app/locales/languages.js
+++ b/app/locales/languages.js
@@ -72,6 +72,25 @@ export async function setUserLocaleOverride(locale) {
   await SetStoreData(LANG_OVERRIDE, locale);
 }
 
+/** Languages only available in dev builds. */
+const DEV_LANGUAGES = __DEV__
+  ? {
+      ar: { label: 'العربية', translation: ar },
+      es: { label: 'Español', translation: es },
+      fr: { label: 'Français', translation: fr },
+      id: { label: 'Indonesia', translation: id },
+      it: { label: 'Italiano', translation: it },
+      ml: { label: 'മലയാളം', translation: ml },
+      nl: { label: 'Nederlands', translation: nl },
+      pl: { label: 'Polski', translation: pl },
+      ro: { label: 'Română', translation: ro },
+      ru: { label: 'Русский', translation: ru },
+      sk: { label: 'Slovak', translation: sk },
+      vi: { label: 'Vietnamese', translation: vi },
+      zh_Hant: { label: '繁體中文', translation: zh_Hant },
+    }
+  : {};
+
 i18next.use(initReactI18next).init({
   interpolation: {
     // React already does escaping
@@ -81,21 +100,9 @@ i18next.use(initReactI18next).init({
   fallbackLng: 'en', // If language detector fails
   returnEmptyString: false,
   resources: {
-    ar: { label: 'العربية', translation: ar },
     en: { label: 'English', translation: en },
-    es: { label: 'Español', translation: es },
-    fr: { label: 'Français', translation: fr },
     ht: { label: 'Kreyòl ayisyen', translation: ht },
-    id: { label: 'Indonesia', translation: id },
-    it: { label: 'Italiano', translation: it },
-    ml: { label: 'മലയാളം', translation: ml },
-    nl: { label: 'Nederlands', translation: nl },
-    pl: { label: 'Polski', translation: pl },
-    ro: { label: 'Română', translation: ro },
-    ru: { label: 'Русский', translation: ru },
-    sk: { label: 'Slovak', translation: sk },
-    vi: { label: 'Vietnamese', translation: vi },
-    zh_Hant: { label: '繁體中文', translation: zh_Hant },
+    ...DEV_LANGUAGES,
   },
 });
 

--- a/app/locales/languages.js
+++ b/app/locales/languages.js
@@ -107,12 +107,12 @@ i18next.use(initReactI18next).init({
 });
 
 /** The known locale list */
-export const LOCALE_LIST = Object.entries(i18next.options.resources).map(
-  ([langCode, lang]) => ({
+export const LOCALE_LIST = Object.entries(i18next.options.resources)
+  .map(([langCode, lang]) => ({
     value: langCode,
     label: lang.label,
-  }),
-);
+  }))
+  .sort((a, b) => a.value > b.value);
 
 /** A map of locale code to name. */
 export const LOCALE_NAME = Object.entries(i18next.options.resources).reduce(


### PR DESCRIPTION
Filters out extra languages for the first release, until we have EULAs in place.

## How to test

Check language list in dev mode

Check language list in non-dev mode with CMD+m -> settings -> disable Dev mode -> restart react native

<img width="307" alt="Screen Shot 2020-04-23 at 4 16 53 PM" src="https://user-images.githubusercontent.com/702990/80158792-40ef0080-857e-11ea-9715-833a4bf8ee30.png">

