### PR TITLE
HTML EULA views

### DIFF
--- a/app/components/EulaModal.js
+++ b/app/components/EulaModal.js
@@ -1,29 +1,21 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  Image,
-  Modal,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
-} from 'react-native';
-import { ScrollView } from 'react-native-gesture-handler';
+import { Image, Modal, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import WebView from 'react-native-webview';
 
 import closeIcon from '../assets/images/closeIcon.png';
-import colors from '../constants/colors';
 import Colors from '../constants/colors';
 import { Theme } from '../constants/themes';
+import en_html from '../locales/eula/en_html';
+import ht_html from '../locales/eula/ht_html';
 import ButtonWrapper from './ButtonWrapper';
 import { Checkbox } from './Checkbox';
 import { Typography } from './Typography';
 
-const eula_en = <Text>English</Text>;
-
-const EULA_LANGUAGES = {
-  en: eula_en,
-  ht: <Text>Haitian</Text>,
+const EULA_FILES = {
+  en: en_html,
+  ht: ht_html,
 };
 
 export const EulaModal = ({ selectedLocale, continueFunction }) => {
@@ -32,7 +24,7 @@ export const EulaModal = ({ selectedLocale, continueFunction }) => {
   const { t } = useTranslation();
 
   // Pull the EULA in the correct language, with en as fallback
-  const eulaText = EULA_LANGUAGES[selectedLocale] || eula_en;
+  const html = EULA_FILES[selectedLocale] || en_html;
 
   return (
     <>
@@ -49,7 +41,14 @@ export const EulaModal = ({ selectedLocale, continueFunction }) => {
               <TouchableOpacity onPress={() => setModalVisibility(false)}>
                 <Image source={closeIcon} style={styles.closeIcon} />
               </TouchableOpacity>
-              <ScrollView>{eulaText}</ScrollView>
+              <WebView
+                style={{ flex: 1 }}
+                source={{ html }}
+                originWhitelist={['*']}
+                allowFileAccess
+                domStorageEnabled
+                javaScriptEnabled
+              />
             </View>
           </SafeAreaView>
           <Theme use='violet'>
@@ -89,8 +88,8 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: 'column',
     justifyContent: 'space-between',
-    color: colors.PRIMARY_TEXT,
-    backgroundColor: colors.WHITE,
+    color: Colors.PRIMARY_TEXT,
+    backgroundColor: Colors.WHITE,
   },
   ctaBox: {
     padding: 25,

--- a/app/components/EulaModal.js
+++ b/app/components/EulaModal.js
@@ -41,14 +41,7 @@ export const EulaModal = ({ selectedLocale, continueFunction }) => {
               <TouchableOpacity onPress={() => setModalVisibility(false)}>
                 <Image source={closeIcon} style={styles.closeIcon} />
               </TouchableOpacity>
-              <WebView
-                style={{ flex: 1 }}
-                source={{ html }}
-                originWhitelist={['*']}
-                allowFileAccess
-                domStorageEnabled
-                javaScriptEnabled
-              />
+              <WebView style={{ flex: 1 }} source={{ html }} />
             </View>
           </SafeAreaView>
           <Theme use='violet'>

--- a/app/locales/eula/en_html.js
+++ b/app/locales/eula/en_html.js
@@ -1,0 +1,691 @@
+export default `
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta name="viewport"
+        content="width=device-width, initial-scale=1.0">
+</head>
+
+<body>
+  <p>
+    <strong>Terms of Use</strong>
+  </p>
+  <p>
+    <strong>Last Updated Date: April 23, 2020</strong>
+  </p>
+  <p>
+    PLEASE READ THIS TERMS OF USE AGREEMENT (THE <strong>“TERMS OF USE” </strong>OR
+    <strong>“AGREEMENT”</strong>) CAREFULLY. THE SAFE PATH MOBILE APPLICATION (THE
+    “<strong>APPLICATION”</strong>), AND THE FEATURES AND INFORMATION IN IT ARE CONTROLLED BY PATH
+    CHECK, INC. (“<strong>PCI</strong>”). THESE TERMS OF USE GOVERN THE USE OF THE APPLICATION AND
+    APPLY TO ALL USERS USING THE APPLICATION IN ANY WAY, INCLUDING THE FEATURES THEREIN. BY CLICKING
+    ON THE “I ACCEPT” BUTTON AND/OR DOWNLOADING THE APPLICATION, YOU REPRESENT THAT (1) YOU HAVE
+    READ, UNDERSTAND, AND AGREE TO BE BOUND BY THE TERMS OF USE, (2) YOU ARE OF LEGAL AGE TO FORM A
+    BINDING CONTRACT WITH PCI, AND (3) YOU HAVE THE AUTHORITY TO ENTER INTO THE TERMS OF USE.
+    <strong>IF YOU DO NOT AGREE TO BE BOUND BY THE TERMS OF USE, YOU MAY NOT ACCESS OR USE THE
+      APPLICATION</strong>.
+  </p>
+  <p>
+    <strong>PLEASE BE AWARE THAT SECTION 13 OF THIS AGREEMENT, BELOW, CONTAINS PROVISIONS GOVERNING
+      HOW DISPUTES THAT YOU AND WE HAVE AGAINST EACH OTHER ARE RESOLVED, INCLUDING, WITHOUT
+      LIMITATION, ANY DISPUTES THAT AROSE OR WERE ASSERTED PRIOR TO THE EFFECTIVE DATE OF THIS
+      AGREEMENT. IN PARTICULAR, IT CONTAINS AN ARBITRATION AGREEMENT WHICH WILL, WITH LIMITED
+      EXCEPTIONS, REQUIRE DISPUTES BETWEEN US TO BE SUBMITTED TO BINDING AND FINAL ARBITRATION.
+      UNLESS YOU OPT OUT OF THE ARBITRATION AGREEMENT: (1) YOU WILL ONLY BE PERMITTED TO PURSUE
+      DISPUTES OR CLAIMS AND SEEK RELIEF AGAINST US ON AN INDIVIDUAL BASIS, NOT AS A PLAINTIFF OR
+      CLASS MEMBER IN ANY CLASS OR REPRESENTATIVE ACTION OR PROCEEDING; AND (2) YOU ARE WAIVING YOUR
+      RIGHT TO PURSUE DISPUTES OR CLAIMS AND SEEK RELIEF IN A COURT OF LAW AND TO HAVE A JURY TRIAL.
+    </strong>
+  </p>
+  <p>
+    <strong>ANY DISPUTE, CLAIM OR REQUEST FOR RELIEF RELATING IN ANY WAY TO YOUR USE OF THE
+      APPLICATION WILL BE GOVERNED AND INTERPRETED BY AND UNDER THE LAWS OF THE COMMONWEALTH OF
+      MASSACHUSETTS, CONSISTENT WITH THE FEDERAL ARBITRATION ACT, WITHOUT GIVING EFFECT TO ANY
+      PRINCIPLES THAT PROVIDE FOR THE APPLICATION OF THE LAW OF ANY OTHER JURISDICTION. THE UNITED
+      NATIONS CONVENTION ON CONTRACTS FOR THE INTERNATIONAL SALE OF GOODS IS EXPRESSLY EXCLUDED FROM
+      THIS AGREEMENT. </strong>
+  </p>
+  <p>
+    PLEASE NOTE THAT THIS AGREEMENT IS SUBJECT TO CHANGE BY PCI IN ITS SOLE DISCRETION AT ANY TIME.
+    When changes are made, PCI will make a new copy of the Terms of Use available within the
+    Application. We will also update the “Last Updated” date at the top of the Terms of Use. Your
+    continued use of the Application after a change to the Terms of Use is made constitutes
+    acceptance. PLEASE REGULARLY CHECK THE APPLICATION TO VIEW THE MOST CURRENT TERMS.
+  </p>
+  <ol>
+
+    <li>
+      <strong>USE OF THE APPLICATION.</strong>
+      <ol>
+
+        <li>
+          <strong>Definitions</strong>. As used in these Terms of Use, the following definitions
+          apply:
+          <p>
+            “<strong>App User</strong>” means an individual natural person who has downloaded the
+            Application under these Terms of Use.
+          </p>
+          <p>
+            “<strong>Location History</strong>” means location data collected from an App User’s
+            mobile device leveraging GPS, Bluetooth and/or other features or software, that the App
+            User elects to have recorded and stored within the Application installed on the App
+            User’s mobile device.
+          </p>
+          <p>
+            “<strong>Publicly Available Safe Places Data</strong>” means anonymized maps of public
+            places where individuals diagnosed with Covid-19 have visited and data files of times
+            they visited such places, as compiled and created by a third party, and made available
+            via such third party’s Third Party Safe Places Web App.
+          </p>
+          <p>
+            “<strong>Safe Places Software</strong>” means open-source software, available at <a
+               href="https://github.com/tripleblindmarket/safe-places">https://github.com/tripleblindmarket/safe-places</a>,
+            that facilitates contact tracing and related tasks, and is designed for use by third
+            parties, such as government agencies.
+          </p>
+          <p>
+            “<strong>Third Party Safe Places Web App</strong>” means a web-based application owned
+            and operated by a third party, such as a government agency, that employs Safe Places
+            Software to, among other things, publish Publicly Available Safe Places Data.
+          </p>
+          <ol>
+
+            <li>
+              <strong>Application Features and Functionality.</strong> The Application is designed
+              to enable App Users, <span style="text-decoration:underline;">at their option</span>:
+              (a) to record their Location History and to store such data locally in the Application
+              downloaded to their mobile device, (b) to access Publicly Available Safe Places Data
+              from one or more Third Party Safe Places Web Apps and download it to the Safe Paths
+              App downloaded on their mobile device, and (c) to share their stored Location History
+              with third parties that they choose.
+
+            <li><strong>Application License. </strong>The Application and the information and
+              content available therein are protected by copyright laws throughout the world.
+              Subject to your compliance with this Agreement, PCI grants you a limited
+              non-exclusive, non-transferable, non-sublicensable, revocable license to download,
+              install and use a copy of the Application on a single mobile device or computer that
+              you own or control and to run such copy of the Application solely for your own
+              personal or internal business purposes. Certain components or libraries included in or
+              bundled with the Application constitute open source software and are licensed under
+              open source licenses. To the extent required by such open source licenses, the terms
+              of such licenses will apply in lieu of the terms of this Section 1.3, solely with
+              respect to those components or libraries that are licensed under such open source
+              licenses. For a copy of such open source licenses, visit <a
+                 href="https://github.com/tripleblindmarket/covid-safe-paths/blob/develop/LICENSE">https://github.com/tripleblindmarket/covid-safe-paths/blob/develop/LICENSE</a>.
+              Furthermore, with respect to any Application accessed through or downloaded from the
+              Apple App Store (an<strong> “App Store Sourced Application”</strong>), you will only
+              use the App Store Sourced Application (a) on an Apple-branded product that runs the
+              iOS (Apple’s proprietary operating system) and (b) as permitted by the “Usage Rules”
+              set forth in the Apple App Store Terms of Service. Notwithstanding the first sentence
+              in this section, with respect to any Application accessed through or downloaded from
+              the Google Play store (a “<strong>Google Play Sourced Application</strong>”), you may
+              have additional license rights with respect to use of the Application on a shared
+              basis within your designated family group.
+
+            <li><strong>Updates.</strong> You understand that to keep the Application most useful
+              for App Users and to accommodate bug fixes and other technological changes, PCI may
+              make updates to the Application after you download the Application. These updates will
+              be made available to App Users from the third party from whom you received the
+              Application license, e.g., the Apple App Store or Google Play (each, an <strong>“App
+                Store”</strong>). You will have the ability, at your option, to download any updates
+              to the Application that we make freely available through such channels. We do not
+              require you to install any updates in order for you to continue using the Application
+              after we make such updates available. This is because we do not retain any information
+              about you when you download the Application. Therefore, we will not know whether you
+              have installed any such updates. Accordingly, you acknowledge and agree that if you
+              elect NOT to install available updates, the Application may not operate in accordance
+              with publicly available documentation regarding the features and functionality of the
+              Application, which documentation may be updated after the time you originally
+              downloaded it. In addition, you may need to update third-party software from time to
+              time in order to use the Application. Any updates issued by PCI and installed by you
+              shall be deemed the Application and shall be governed by this Safe Places EULA or any
+              subsequent end user license agreement accompanying the update.
+
+            <li><strong>Necessary Equipment and Software.</strong> You must provide all equipment
+              and software necessary to download and use the Application and to connect to any third
+              party services or sites, including but not limited to, a mobile device that is
+              suitable to connect with and use the Application. You are solely responsible for any
+              fees, including Internet connection or mobile fees, that you incur when accessing the
+              Application.
+
+            <li><strong>Responsibility for Location History and Other Data Collected and Stored by
+                You. </strong> PCI has no access to the Location History or any other data you
+              collect, receive and store in the installed Application or otherwise on your mobile
+              device. Therefore, PCI has no responsibility or liability for the deletion or accuracy
+              of the Location History or other data you collect, receive or store in the Application
+              or the failure to store, transmit or receive transmission of Location History or other
+              data; or the security, privacy, storage, or transmission of other communications
+              originating with or involving use of the Application.
+            </li>
+          </ol>
+
+        <li><strong>OWNERSHIP.</strong>
+          <ol>
+
+            <li>
+              <strong>Application.</strong> Except with respect to your Location History and other
+              data you may collect, retrieve from third parties and store in the Application on your
+              device, you agree that PCI and its suppliers own all rights, title and interest in and
+              to the Application. You will not remove, alter or obscure any copyright, trademark,
+              service mark or other proprietary rights notices incorporated in or accompanying the
+              Application.
+
+            <li><strong>Trademarks.</strong> COVID Safe Paths and all related graphics, logos,
+              service marks and trade names used on or in connection with the Application or in
+              connection therewith are the trademarks of PCI and may not be used without permission
+              in connection with your, or any third-party, products or services. Other trademarks,
+              service marks and trade names that may appear on or in the Application are the
+              property of their respective owners.
+            </li>
+          </ol>
+
+        <li><strong>COLLECTION AND USE OF YOUR PERSONAL INFORMATION. </strong>You acknowledge that
+          the Application may collect personal information about you (through your choice to store
+          information in the Application or through automatic technology tools), including your
+          Location History. You acknowledge that the Application may provide you with opportunities
+          to share personal information about yourself, including your Location History with others.
+          All personal information in connection with this Application is subject to our Privacy
+          Policy. By downloading, installing, using, and providing personal information to or
+          through this Application, you consent to all actions taken by us with respect to your
+          personal information in compliance with the Privacy Policy. For some features of the
+          Application, specific consent is required. In addition, you may choose to disclose,
+          through other means not associated with the Application, any part of your personal
+          information to family members, doctors, health care providers, governmental agencies, or
+          other individuals or entities. We recommend that you make your choices regarding sharing
+          your personal information, through the Application or otherwise, carefully. We will have
+          no liability for any consequences that may result because you have released or shared
+          information, through the Application or otherwise, with a third party.
+
+        <li><strong>FEEDBACK</strong>. If you provide PCI with any ideas, suggestions, documents,
+          and/or proposals (<strong>“Feedback”</strong>) via email or another means, you do so at
+          your own risk and you acknowledge and agree that PCI has no obligations (including without
+          limitation obligations of confidentiality) with respect to such Feedback. You represent
+          and warrant that you have all rights necessary to submit the Feedback. You hereby grant to
+          PCI a fully paid, royalty-free, perpetual, irrevocable, worldwide, non-exclusive, and
+          fully sublicensable right and license to use, reproduce, perform, display, distribute,
+          adapt, modify, re-format, create derivative works of, and otherwise commercially or
+          non-commercially exploit in any manner, any and all Feedback, and to sublicense the
+          foregoing rights, in connection with the operation and maintenance of the Application, any
+          other PCI products or services, or PCI’s business.
+
+        <li><strong>APP STORES. </strong>You acknowledge and agree that the availability of the
+          Application is dependent on the App Store from whom you received the Application license.
+          You acknowledge that this Agreement is between you and PCI and not with the App Store.
+          PCI, not the App Store, is solely responsible for the Application, including the content
+          PCI makes available therein, and the maintenance, support services, and warranty therefor,
+          and addressing any claims relating thereto (e.g., product liability, legal compliance or
+          intellectual property infringement). In order to use the Application, you must have access
+          to a wireless network, and you agree to pay all fees associated with such access. You also
+          agree to pay all fees (if any) charged by the App Store in connection with the
+          Application. You agree to comply with, and your license to use the Application is
+          conditioned upon your compliance with all terms of agreement imposed by the applicable App
+          Store when using the Application. You acknowledge that the App Store (and its
+          subsidiaries) are third-party beneficiaries of this Agreement and will have the right to
+          enforce it.
+
+        <li><strong>FEES. </strong>No fees shall be payable under this Agreement for the rights
+          granted under this Agreement. You acknowledge and agree that this fee arrangement is made
+          in consideration for the mutual covenants set forth in this Agreement, including your
+          obligations hereunder, and the disclaimers, exclusions, and limitations of liability set
+          forth herein.
+
+        <li><strong>INDEMNIFICATION. </strong>You agree to indemnify and hold PCI, its parents,
+          subsidiaries, affiliates, officers, employees, volunteers, agents, partners, suppliers,
+          and licensors (each, a “<strong>PCI Party</strong>” and collectively, the <strong>“PCI
+            Parties”</strong>) harmless from any losses, costs, liabilities and expenses (including
+          reasonable attorneys’ fees) relating to or arising out of any and all of the following:
+          (a) your use of, or inability to use the Application; (b) your violation of this
+          Agreement; (c) your violation of any rights of another party; or (d) your violation of any
+          applicable laws, rules or regulations. PCI reserves the right, at its own cost, to assume
+          the exclusive defense and control of any matter otherwise subject to indemnification by
+          you, in which event you will fully cooperate with PCI in asserting any available defenses.
+          This provision does not require you to indemnify any of the PCI Parties for any
+          unconscionable commercial practice by such party or for such party’s fraud, deception,
+          false promise, misrepresentation or concealment, suppression or omission of any material
+          fact in connection with the Application provided hereunder. You agree that the provisions
+          in this section will survive any termination of this Agreement and/or your use of or
+          access to Application.
+
+        <li><strong>DISCLAIMER OF WARRANTIES AND CONDITIONS.</strong>
+          <ol>
+
+            <li>
+              <strong>As Is.</strong> YOU EXPRESSLY UNDERSTAND AND AGREE THAT TO THE EXTENT
+              PERMITTED BY APPLICABLE LAW, YOUR USE OF THE APPLICATION IS AT YOUR SOLE RISK, AND THE
+              APPLICATION IS PROVIDED ON AN “AS IS” AND “AS AVAILABLE” BASIS, WITH ALL FAULTS. THE
+              PCI PARTIES EXPRESSLY DISCLAIM ALL WARRANTIES, REPRESENTATIONS, AND CONDITIONS OF ANY
+              KIND, WHETHER EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+              WARRANTIES OR CONDITIONS OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+              NON-INFRINGEMENT ARISING FROM USE OF THE APPLICATION.
+              <ol>
+
+                <li>
+                  THE PCI PARTIES MAKE NO WARRANTY, REPRESENTATION OR CONDITION THAT: (1) THE
+                  APPLICATION OR ITS FEATURES WILL MEET YOUR REQUIREMENTS; (2) YOUR USE OF THE
+                  APPLICATION WILL BE UNINTERRUPTED, TIMELY, SECURE OR ERROR-FREE; OR (3) THE
+                  RESULTS THAT MAY BE OBTAINED FROM USE OF THE APPLICATION WILL BE ACCURATE OR
+                  RELIABLE.
+
+                <li>ANY CONTENT DOWNLOADED FROM OR OTHERWISE ACCESSED THROUGH THE APPLICATION IS
+                  ACCESSED AT YOUR OWN RISK, AND YOU SHALL BE SOLELY RESPONSIBLE FOR ANY DAMAGE TO
+                  YOUR PROPERTY, INCLUDING, BUT NOT LIMITED TO, YOUR COMPUTER SYSTEM AND ANY DEVICE
+                  YOU USE TO ACCESS THE APPLICATION, OR ANY OTHER LOSS THAT RESULTS FROM ACCESSING
+                  SUCH CONTENT.
+
+                <li>THE AVAILABILITY OF THE APPLICATION AND ITS FEATURES MAY BE SUBJECT TO DELAYS,
+                  CANCELLATIONS AND OTHER DISRUPTIONS. PCI MAKES NO WARRANTY, REPRESENTATION OR
+                  CONDITION WITH RESPECT TO THE APPLICATION OR ITS FEATURES, INCLUDING BUT NOT
+                  LIMITED TO, THE QUALITY, EFFECTIVENESS, REPUTATION AND OTHER CHARACTERISTICS
+                  THEREOF.
+
+                <li>NO ADVICE OR INFORMATION, WHETHER ORAL OR WRITTEN, OBTAINED FROM PCI OR THROUGH
+                  THE APPLICATION WILL CREATE ANY WARRANTY NOT EXPRESSLY MADE HEREIN.
+
+                <li>FROM TIME TO TIME, PCI MAY OFFER NEW “BETA” FEATURES OR TOOLS WITH WHICH ITS
+                  USERS MAY EXPERIMENT. SUCH FEATURES OR TOOLS ARE OFFERED SOLELY FOR EXPERIMENTAL
+                  PURPOSES AND WITHOUT ANY WARRANTY OF ANY KIND, AND MAY BE MODIFIED OR DISCONTINUED
+                  AT PCI’S SOLE DISCRETION. THE PROVISIONS OF THIS SECTION APPLY WITH FULL FORCE TO
+                  SUCH FEATURES OR TOOLS.
+                </li>
+              </ol>
+
+            <li><strong>NOT INTENDED AS MEDICAL ADVICE.</strong> YOU ACKNOWLEDGE THAT THE
+              INFORMATION IN THE APPLICATION IS PROVIDED FOR GENERAL INFORMATIONAL PURPOSES ONLY. IT
+              IS NOT INTENDED AS MEDICAL ADVICE OF ANY KIND NOR IS IT INTENDED TO DIAGNOSE, TREAT,
+              CURE OR PREVENT ANY DISEASE OR MEDICAL CONDITION. THE INFORMATION PRESENTED IN THE
+              APPLICATION SHOULD NOT BE INTERPRETED OR CONSTRUED IN ANY WAY AS A REPLACEMENT OR
+              SUBSTITUTE FOR MEDICAL ADVICE PROVIDED BY YOUR DOCTOR OR OTHER QUALIFIED HEALTHCARE
+              PROVIDER. YOU SHOULD NOT DISREGARD, AVOID OR DELAY OBTAINING MEDICAL ADVICE OR
+              TREATMENT FROM YOUR DOCTOR OR OTHER QUALIFIED HEALTHCARE PROVIDER DUE TO ANY
+              INFORMATION PROVIDED IN THE APPLICATION. UNDER NO CIRCUMSTANCES SHOULD YOU ALTER YOUR
+              EXISTING MEDICAL TREATMENT, MEDICATION REGIMEN, OR ANY OTHER RELATED HEALTHCARE
+              ACTIVITIES BASED ON ANY INFORMATION PROVIDED IN THE APPLICATION. IT IS IMPORTANT FOR
+              YOU TO DISCUSS YOUR TREATMENT OPTIONS, AND ANY QUESTIONS THAT YOU MAY HAVE, WITH YOUR
+              DOCTOR OR OTHER QUALIFIED HEALTHCARE PROVIDER.
+
+            <li>In making the Application available for download, PCI’s goal is to provide
+              individuals with a useful tool for contact tracing. However, the utility of the
+              Application’s features is dependent upon a number of factors that are outside the
+              control of PCI, such as the reliability of GPS sensors, whether individuals are
+              carrying their mobile devices, as well as the accuracy, reliability, availability,
+              effectiveness or correct use of individual’s mobile devices and GPS sensors, all of
+              which are used to create Location History, and for any Publicly Available Safe Places
+              Data that you may upload into your Application from third party source, the accuracy
+              and completeness of such data. Your Location History or other data may be unavailable,
+              inaccurate or incomplete. Use of the Application should not replace your good judgment
+              and common sense.
+
+            <li><strong>No Liability for Conduct of Third Parties.</strong> YOU ACKNOWLEDGE AND
+              AGREE THAT PCI PARTIES ARE NOT LIABLE, AND YOU AGREE NOT TO SEEK TO HOLD PCI PARTIES
+              LIABLE, FOR THE CONDUCT OR OMISSIONS OF THIRD PARTIES, INCLUDING THE ACTIONS OF ANY
+              THIRD PARTY OPERATING A THIRD PARTY SAFE PLACES WEB APP OR ANY GOVERNMENTAL AGENCY
+              WITH WHICH YOU CHOOSE TO INTERACT IN CONNECTION WITH YOUR USE OF THE APPLICATION, AND
+              THAT THE RISK OF INJURY FROM SUCH THIRD PARTIES RESTS ENTIRELY WITH YOU.
+            </li>
+          </ol>
+
+        <li><strong>LIMITATION OF LIABILITY.</strong>
+          <ol>
+
+            <li>
+              <strong>Disclaimer of Certain Damages.</strong> YOU UNDERSTAND AND AGREE THAT IN NO
+              EVENT SHALL THE PCI PARTIES BE LIABLE FOR ANY LOSS OF PROFITS, PERSONAL INJURY,
+              PROPERTY DAMAGE, WRONGFUL DEATH, REVENUE OR DATA, INDIRECT, INCIDENTAL, SPECIAL, OR
+              CONSEQUENTIAL DAMAGES, OR DAMAGES OR COSTS DUE TO LOSS OF PRODUCTION OR USE, BUSINESS
+              INTERRUPTION, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, IN EACH CASE WHETHER OR NOT
+              PCI HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES, ARISING OUT OF OR IN
+              CONNECTION WITH THIS AGREEMENT, ON ANY THEORY OF LIABILITY, RESULTING FROM: (1) THE
+              USE OR INABILITY TO USE THE APPLICATION OR ANY OF ITS ADVERTISED FEATURES; (2)
+              UNAUTHORIZED ACCESS TO OR ALTERATION OF YOUR TRANSMISSIONS OR DATA; OR (3) ANY OTHER
+              MATTER RELATED TO THE APPLICATION, WHETHER BASED ON WARRANTY, COPYRIGHT, CONTRACT,
+              TORT (INCLUDING NEGLIGENCE), OR ANY OTHER LEGAL THEORY. THE FOREGOING CAP ON LIABILITY
+              SHALL NOT APPLY TO LIABILITY OF A PCI PARTY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY
+              A PCI PARTY’S NEGLIGENCE; OR FOR (B) ANY INJURY CAUSED BY A PCI PARTY’S FRAUD OR
+              FRAUDULENT MISREPRESENTATION.
+
+            <li><strong>Cap on Liability.</strong> TO THE MAXIMUM EXTENT PERMITTED BY LAW,
+              NOTWITHSTANDING ANYTHING TO THE CONTRARY CONTAINED HEREIN, OUR LIABILITY TO YOU FOR
+              ANY DAMAGES ARISING FROM OR RELATED TO THESE TERMS OF USE (FOR ANY CAUSE WHATSOEVER
+              AND REGARDLESS OF THE FORM OF THE ACTION), WILL AT ALL TIMES BE LIMITED TO A MAXIMUM
+              OF FIFTY US DOLLARS (U.S. $50). THE EXISTENCE OF MORE THAN ONE CLAIM WILL NOT ENLARGE
+              THIS LIMIT. YOU AGREE THAT OUR SUPPLIERS WILL HAVE NO LIABILITY OF ANY KIND ARISING
+              FROM OR RELATING TO THESE TERMS OF USE.
+
+            <li><strong>Your Data.</strong> EXCEPT FOR PCI’S OBLIGATIONS TO PROTECT YOUR PERSONAL
+              DATA AS SET FORTH IN THE PCI’S PRIVACY POLICY, PCI ASSUMES NO RESPONSIBILITY FOR THE
+              TIMELINESS, DELETION, MIS-DELIVERY OR FAILURE TO STORE ANY CONTENT (INCLUDING YOUR
+              LOCATION HISTORY), USER COMMUNICATIONS OR PERSONALIZATION SETTINGS.
+
+            <li><strong>Basis of the Bargain.</strong> THE LIMITATIONS OF DAMAGES SET FORTH ABOVE
+              ARE FUNDAMENTAL ELEMENTS OF THE BASIS OF THE BARGAIN BETWEEN PCI AND YOU.
+            </li>
+          </ol>
+
+        <li><strong>REMEDIES.</strong>
+          <ol>
+
+            <li>
+              <strong>Violations.</strong> If PCI becomes aware of any possible violations by you of
+              this Agreement, PCI reserves the right to investigate such violations. If, as a result
+              of the investigation, PCI believes that criminal activity has occurred, PCI reserves
+              the right to refer the matter to, and to cooperate with, any and all applicable legal
+              authorities. PCI is entitled, except to the extent prohibited by applicable law, to
+              disclose any information or materials you provide to PCI in connection with your use
+              of the Application, to (a) comply with applicable laws, legal process or governmental
+              request; (b) enforce these Terms of Use, (c) respond to your requests for customer
+              service, or (d) protect the rights, property or personal safety of PCI or the public,
+              and all enforcement or other government officials, as PCI, in its sole discretion
+              believes to be necessary or appropriate.
+            </li>
+          </ol>
+
+        <li><strong>TERM AND TERMINATION. </strong>
+          <ol>
+
+            <li>
+              <strong>Term.</strong> This Agreement commences on the date when you accept them (as
+              described in the preamble above) and remain in full force and effect while you use the
+              Application, unless terminated earlier in accordance with this Agreement.
+
+            <li><strong>Prior Use. </strong> Notwithstanding the foregoing, you hereby acknowledge
+              and agree that this Agreement commenced on the earlier to occur of (a) the date you
+              first used the Application or (b) the date you accepted this Agreement and will remain
+              in full force and effect while you use the Application, unless earlier terminated in
+              accordance with this Agreement.
+
+            <li><strong>Termination by You. </strong>If you want to terminate this Agreement, you
+              may do so by deleting the Application from your mobile device.
+
+            <li><strong>Effect of Termination.</strong> Termination of this Agreement requires you
+              to delete the Application and cease all use of it. All provisions of this Agreement
+              which by their nature should survive, shall survive termination, including without
+              limitation, ownership provisions, warranty disclaimers, and limitation of liability.
+            </li>
+          </ol>
+
+        <li><strong>INTERNATIONAL USERS. </strong>The Application is intended solely for use in the
+          United States of America. PCI makes no representations that the Application is functional
+          in other locations. Those who access or use the Application from other countries do so at
+          their own risk and are responsible for use in compliance with local law.
+
+        <li><strong>DISPUTE RESOLUTION<em>. Please read the following arbitration agreement in this
+              Section (“</em>Arbitration Agreement<em>”) carefully.  It requires U.S. users to
+              arbitrate disputes with PCI and limits the manner in which you can seek relief from
+              us. </em></strong>
+          <ol>
+
+            <li>
+              <strong>Applicability of Arbitration Agreement<em>.</em></strong> You agree that any
+              dispute, claim, or request for relief relating in any way to your access or use of the
+              Application or to any aspect of your relationship with PCI, will be resolved by
+              binding arbitration, rather than in court, except that (1) you may assert claims or
+              seek relief in small claims court if your claims qualify,; and (2) you or PCI may seek
+              equitable relief in court for infringement or other misuse of intellectual property
+              rights (such as trademarks, trade dress, domain names, trade secrets, copyrights, and
+              patents). <strong>This Arbitration Agreement shall apply, without limitation, to all
+                disputes or claims and requests for relief that arose or were asserted before the
+                effective date of this Agreement or any prior version of this Agreement. </strong>
+
+            <li><strong>Arbitration Rules and Forum<em>. </em></strong> The Federal Arbitration Act
+              governs the interpretation and enforcement of this Arbitration Agreement. To begin an
+              arbitration proceeding, you must send a letter requesting arbitration and describing
+              your dispute or claim or request for relief to our registered agent Samuel Hoff c/o
+              Pierce & Mandell, P.C. 11 Beacon Street Suite 800, Boston MA 02108. The arbitration
+              will be conducted by JAMS, an established alternative dispute resolution
+              provider.  Disputes involving claims, counterclaims, or request for relief under
+              $250,000, not inclusive of attorneys’ fees and interest, shall be subject to JAMS’s
+              most current version of the Streamlined Arbitration Rules and procedures available at
+              http://www.jamsadr.com/rules-streamlined-arbitration/; all other disputes shall be
+              subject to JAMS’s most current version of the Comprehensive Arbitration Rules and
+              Procedures, available at http://www.jamsadr.com/rules-comprehensive-arbitration/.
+              JAMS’s rules are also available at www.jamsadr.com or by calling JAMS at 800-352-5267.
+              If JAMS is not available to arbitrate, the parties will select an alternative arbitral
+              forum. If the arbitrator finds that you cannot afford to pay JAMS’s filing,
+              administrative, hearing and/or other fees and cannot obtain a waiver from JAMS, PCI
+              will pay them for you. In addition, PCI will reimburse all such JAMS’s filing,
+              administrative, hearing and/or other fees for disputes, claims, or requests for relief
+              totaling less than $10,000 unless the arbitrator determines the claims are frivolous.
+              <p>
+                You may choose to have the arbitration conducted by telephone, based on written
+                submissions, or at another mutually agreed location. Any judgment on the award
+                rendered by the arbitrator may be entered in any court of competent jurisdiction.
+              </p>
+              <ol>
+
+                <li>
+                  <strong>Authority of Arbitrator</strong>.  The arbitrator shall have exclusive
+                  authority to (a) determine the scope and enforceability of this Arbitration
+                  Agreement and (b) resolve any dispute related to the interpretation,
+                  applicability, enforceability or formation of this Arbitration Agreement
+                  including, but not limited to, any assertion that all or any part of this
+                  Arbitration Agreement is void or voidable. The arbitration will decide the rights
+                  and liabilities, if any, of you and PCI. The arbitration proceeding will not be
+                  consolidated with any other matters or joined with any other cases or parties.
+                  The arbitrator shall have the authority to grant motions dispositive of all or
+                  part of any claim. The arbitrator shall have the authority to award monetary
+                  damages and to grant any non-monetary remedy or relief available to an individual
+                  under applicable law, the arbitral forum’s rules, and this Agreement (including
+                  the Arbitration Agreement). The arbitrator shall issue a written award and
+                  statement of decision describing the essential findings and conclusions on which
+                  the award is based, including the calculation of any damages awarded.  The
+                  arbitrator has the same authority to award relief on an individual basis that a
+                  judge in a court of law would have.  The award of the arbitrator is final and
+                  binding upon you and us.
+
+                <li><strong>Waiver of Jury Trial</strong>.  YOU AND PCI HEREBY WAIVE ANY
+                  CONSTITUTIONAL AND STATUTORY RIGHTS TO SUE IN COURT AND HAVE A TRIAL IN FRONT OF A
+                  JUDGE OR A JURY. You and PCI are instead electing that all disputes, claims, or
+                  requests for relief shall be resolved by arbitration under this Arbitration
+                  Agreement, except as specified in Section 13.1 above.  An arbitrator can award on
+                  an individual basis the same damages and relief as a court and must follow this
+                  Agreement as a court would. However, there is no judge or jury in arbitration, and
+                  court review of an arbitration award is subject to very limited review.
+
+                <li><strong>Waiver of Class or Other Non-Individualized Relief</strong>.  ALL
+                  DISPUTES, CLAIMS, AND REQUESTS FOR RELIEF WITHIN THE SCOPE OF THIS ARBITRATION
+                  AGREEMENT MUST BE ARBITRATED ON AN INDIVIDUAL BASIS AND NOT ON A CLASS OR
+                  COLLECTIVE BASIS, ONLY INDIVIDUAL RELIEF IS AVAILABLE, AND CLAIMS OF MORE THAN ONE
+                  CUSTOMER OR USER CANNOT BE ARBITRATED OR CONSOLIDATED WITH THOSE OF ANY OTHER
+                  CUSTOMER OR USER. If a decision is issued stating that applicable law precludes
+                  enforcement of any of this subsection’s limitations as to a given dispute, claim,
+                  or request for relief, then such aspect must be severed from the arbitration and
+                  brought into the State or Federal Courts located in the Commonwealth of
+                  Massachusetts. All other disputes, claims, or requests for relief shall be
+                  arbitrated.
+
+                <li><strong>30-Day Right to Opt Out</strong>. You have the right to opt out of the
+                  provisions of this Arbitration Agreement by sending written notice of your
+                  decision to opt out to: legal@pathcheck.org, within 30 days after first becoming
+                  subject to this Arbitration Agreement. Your notice must include your name and
+                  address, your email address, and an unequivocal statement that you want to opt out
+                  of this Arbitration Agreement. If you opt out of this Arbitration Agreement, all
+                  other parts of this Agreement will continue to apply to you. Opting out of this
+                  Arbitration Agreement has no effect on any other arbitration agreements that you
+                  may currently have, or may enter in the future, with us.
+
+                <li><strong>Severability<em>. </em></strong>Except as provided in subsection 13.5,
+                  if any part or parts of this Arbitration Agreement are found under the law to be
+                  invalid or unenforceable, then such specific part or parts shall be of no force
+                  and effect and shall be severed and the remainder of the Arbitration Agreement
+                  shall continue in full force and effect.
+
+                <li><strong>Survival of Agreement<em>. </em></strong>This Arbitration Agreement will
+                  survive the termination of your relationship with PCI.
+
+                <li><strong>Modification</strong>.<strong> </strong>Notwithstanding any provision in
+                  this Agreement to the contrary, we agree that if PCI makes any future material
+                  change to this Arbitration Agreement, you may reject that change within thirty
+                  (30) days of such change becoming effective by writing PCI at the following
+                  address: Path Check, Inc. PO Box 441621, Somerville MA 02144
+                </li>
+              </ol>
+
+            <li><strong>GENERAL PROVISIONS.</strong>
+              <ol>
+
+                <li>
+                  <strong>Electronic Communications.</strong> The communications between you and PCI
+                  may take place via electronic means, whether you send PCI e-mails, or whether PCI
+                  posts notices in the Application or through updates made to the Application in
+                  accordance with this Terms of Use or communicates with you via e-mail. For
+                  contractual purposes, you (a) consent to receive communications from PCI in an
+                  electronic form; and (b) agree that all terms and conditions, agreements, notices,
+                  disclosures, and other communications that PCI provides to you electronically
+                  satisfy any legal requirement that such communications would satisfy if it were to
+                  be in writing. The foregoing does not affect your statutory rights, including but
+                  not limited to the Electronic Signatures in Global and National Commerce Act at 15
+                  U.S.C. §7001 et seq. (“E-Sign”).
+
+                <li><strong>Release.</strong> You hereby release the PCI Parties and their
+                  successors from claims, demands, any and all losses, damages, rights, and actions
+                  of any kind, including personal injuries, death, and property damage, that is
+                  either directly or indirectly related to or arises from any interactions with or
+                  conduct of operators of Third Party Safe Places Web Apps, healthcare providers,
+                  governmental agencies, of any kind arising in connection with or as a result of
+                  this Agreement or your use of the Application. If you are a California resident,
+                  you hereby waive California Civil Code Section 1542, which states, “A general
+                  release does not extend to claims that the creditor or releasing party does not
+                  know or suspect to exist in his or her favor at the time of executing the release
+                  and that, if known by him or her, would have materially affected his or her
+                  settlement with the debtor or released party.” The foregoing release does not
+                  apply to any claims, demands, or any losses, damages, rights and actions of any
+                  kind, including personal injuries, death or property damage for any unconscionable
+                  commercial practice by a PCI Party or for such party’s fraud, deception, false,
+                  promise, misrepresentation or concealment, suppression or omission of any material
+                  fact in connection with the Application provided hereunder.
+
+                <li><strong>Assignment.</strong> This Agreement, and your rights and obligations
+                  hereunder, may not be assigned, subcontracted, delegated or otherwise transferred
+                  by you without PCI’s prior written consent, and any attempted assignment,
+                  subcontract, delegation, or transfer in violation of the foregoing will be null
+                  and void.
+
+                <li><strong>Force Majeure.</strong> PCI shall not be liable for any delay or failure
+                  to perform resulting from causes outside its reasonable control, including, but
+                  not limited to, acts of God, war, terrorism, riots, embargos, acts of civil or
+                  military authorities, fire, floods, accidents, strikes or shortages of
+                  transportation facilities, fuel, energy, labor or materials.
+
+                <li><strong>Questions, Complaints, Claims.</strong> If you have any questions,
+                  complaints or claims with respect to the Application, please contact us at:
+                  support@pathcheck.org.
+
+                <li><strong>Exclusive Venue.</strong> To the extent the parties are permitted under
+                  this Agreement to initiate litigation in a court, both you and PCI agree that all
+                  claims and disputes arising out of or relating to this Agreement will be litigated
+                  exclusively in the state or federal courts located in Boston, Massachusetts.
+
+                <li><strong>Governing Law </strong>THE TERMS AND ANY ACTION RELATED THERETO WILL BE
+                  GOVERNED AND INTERPRETED BY AND UNDER THE LAWS OF THE COMMONWEALTH OF
+                  MASSACHUSETTS, CONSISTENT WITH THE FEDERAL ARBITRATION ACT, WITHOUT GIVING EFFECT
+                  TO ANY PRINCIPLES THAT PROVIDE FOR THE APPLICATION OF THE LAW OF ANOTHER
+                  JURISDICTION. THE UNITED NATIONS CONVENTION ON CONTRACTS FOR THE INTERNATIONAL
+                  SALE OF GOODS DOES NOT APPLY TO THIS AGREEMENT.
+
+                <li><strong>Choice of Language.</strong> It is the express wish of the parties that
+                  this Agreement and all related documents have been drawn up in English.
+
+                <li><strong>Notice.</strong> You may give notice to PCI at the following address:
+                  Path Check, Inc. PO Box 441621, Somerville MA 02144. Such notice shall be deemed
+                  given when received by PCI by letter delivered by nationally recognized overnight
+                  delivery service or first class postage prepaid mail at the above address.
+
+                <li><strong>Waiver.</strong> Any waiver or failure to enforce any provision of this
+                  Agreement on one occasion will not be deemed a waiver of any other provision or of
+                  such provision on any other occasion.
+
+                <li><strong>Severability.</strong> If any portion of this Agreement is held invalid
+                  or unenforceable, that portion shall be construed in a manner to reflect, as
+                  nearly as possible, the original intention of the parties, and the remaining
+                  portions shall remain in full force and effect.
+
+                <li><strong>Export Control.</strong> You may not use, export, import, or transfer
+                  the Application except as authorized by U.S. law, the laws of the jurisdiction in
+                  which you obtained PCI Properties, and any other applicable laws. In particular,
+                  but without limitation, the Application may not be exported or re-exported (a)
+                  into any United States embargoed countries, or (b) to anyone on the U.S. Treasury
+                  Department’s list of Specially Designated Nationals or the U.S. Department of
+                  Commerce’s Denied Person’s List or Entity List. By using the Application, you
+                  represent and warrant that (y) you are not located in a country that is subject to
+                  a U.S. Government embargo, or that has been designated by the U.S. Government as a
+                  “terrorist supporting” country and (z) you are not listed on any U.S. Government
+                  list of prohibited or restricted parties. You also will not use the Application
+                  for any purpose prohibited by U.S. law, including the development, design,
+                  manufacture or production of missiles, nuclear, chemical or biological weapons.
+                  You acknowledge and agree that products, services or technology provided by PCI
+                  are subject to the export control laws and regulations of the United States. You
+                  shall comply with these laws and regulations and shall not, without prior U.S.
+                  government authorization, export, re-export, or transfer PCI products, services or
+                  technology, either directly or indirectly, to any country in violation of such
+                  laws and regulations.
+
+                <li><strong>Accessing and Downloading the Application from iTunes.</strong> The
+                  following applies to any App Store Sourced Application accessed through or
+                  downloaded from the Apple App Store:
+                  <ol>
+
+                    <li>
+                      You acknowledge and agree that (i) this Agreement is concluded between you and
+                      PCI only, and not Apple, and (ii) PCI, not Apple, is solely responsible for
+                      the App Store Sourced Application and content thereof. Your use of the App
+                      Store Sourced Application must comply with the App Store Terms of Service.
+
+                    <li>You acknowledge that Apple has no obligation whatsoever to furnish any
+                      maintenance and support services with respect to the App Store Sourced
+                      Application.
+
+                    <li>In the event of any failure of the App Store Sourced Application to conform
+                      to any applicable warranty, you may notify Apple, and Apple will refund the
+                      purchase price for the App Store Sourced Application to you and to the maximum
+                      extent permitted by applicable law, Apple will have no other warranty
+                      obligation whatsoever with respect to the App Store Sourced Application. As
+                      between PCI and Apple, any other claims, losses, liabilities, damages, costs
+                      or expenses attributable to any failure to conform to any warranty will be the
+                      sole responsibility of PCI.
+
+                    <li>You and PCI acknowledge that, as between PCI and Apple, Apple is not
+                      responsible for addressing any claims you have or any claims of any third
+                      party relating to the App Store Sourced Application or your possession and use
+                      of the App Store Sourced Application, including, but not limited to: (i)
+                      product liability claims; (ii) any claim that the App Store Sourced
+                      Application fails to conform to any applicable legal or regulatory
+                      requirement; and (iii) claims arising under consumer protection or similar
+                      legislation.
+
+                    <li>You and PCI acknowledge that, in the event of any third-party claim that the
+                      App Store Sourced Application or your possession and use of that App Store
+                      Sourced Application infringes that third party’s intellectual property rights,
+                      as between PCI and Apple, PCI, not Apple, will be solely responsible for the
+                      investigation, defense, settlement and discharge of any such intellectual
+                      property infringement claim to the extent required by this Agreement.
+
+                    <li>You and PCI acknowledge and agree that Apple, and Apple’s subsidiaries, are
+                      third-party beneficiaries of this Agreement as related to your license of the
+                      App Store Sourced Application, and that, upon your acceptance of the terms and
+                      conditions of this Agreement, Apple will have the right (and will be deemed to
+                      have accepted the right) to enforce this Agreement as related to your license
+                      of the App Store Sourced Application against you as a third-party beneficiary
+                      thereof.
+
+                    <li>Without limiting any other terms of this Agreement, you must comply with all
+                      applicable third-party terms of agreement when using the App Store Sourced
+                      Application.
+                    </li>
+                  </ol>
+
+                <li><strong>Consumer Complaints.</strong> In accordance with California Civil Code
+                  §1789.3, you may report complaints to the Complaint Assistance Unit of the
+                  Division of Consumer Services of the California Department of Consumer Affairs by
+                  contacting them in writing at 1625 North Market Blvd., Suite N 112, Sacramento, CA
+                  95834, or by telephone at (800) 952-5210.
+
+                <li><strong>Entire Agreement.</strong> This Agreement is the final, complete and
+                  exclusive agreement of the parties with respect to the subject matter hereof and
+                  supersedes and merges all prior discussions between the parties with respect to
+                  such subject matter.
+</body>
+
+</html>
+
+`;

--- a/app/locales/eula/eula_en.js
+++ b/app/locales/eula/eula_en.js
@@ -1,4 +1,0 @@
-export const eula_en = `**Terms of Use**
-
-**Last Updated Date: April 23, 2020**
-`;

--- a/app/locales/eula/eula_ht.js
+++ b/app/locales/eula/eula_ht.js
@@ -1,4 +1,0 @@
-export const eula_ht = `**COVID Safe Paths**
-
-**Tradiksyon ayisyen isit la**
-`;

--- a/app/locales/eula/ht_html.js
+++ b/app/locales/eula/ht_html.js
@@ -1,0 +1,814 @@
+export default `
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta name="viewport"
+        content="width=device-width, initial-scale=1.0">
+
+  <style>
+    ol {
+      counter-reset: item
+    }
+
+    li {
+      display: block
+    }
+
+    li:before {
+      content: counters(item, ".") " ";
+      counter-increment: item
+    }
+  </style>
+</head>
+
+<body>
+  <p>
+    <strong>Règleman itilizasyon<br>
+    </strong>
+  </p>
+  <p>
+    <strong>Dènye Mizajou Dat: 23 Avril 2020</strong><br>
+
+  </p>
+  <p>
+    TANPRI LI RÈGLEMAN ITILIZASYON AKÒ SA YO ( <strong>"KONDISYON POU ITILIZE"</strong> OU
+    <strong>"AKÒ"</strong>) AVÈK ATANSYON. APLIKASYON MOBIL SAFE PATHS ‘CHASE KOWONA’
+    (<strong>"APLIKASYON"</strong> an), AK karakteristik ak enfòmasyon ki ladanl yo ap kontwole pa
+    Path Check, INC. ("PCI"). Règleman itilizasyon sa yo gouvène itilizasyon aplikasyon an epi
+    aplike
+    pou tout itilizatè ki itilize aplikasyon an nan nenpòt fason, ki gen ladan karakteristik sa yo.
+    SIW klike sou BOUTON "mwen aksepte" ak / oswa TELECHAJE APLIKASYON an, ou repwezante ke (1) ou
+    li,
+    konprann, ak dakò pou yo atache pa règleman itilizasyon yo, (2) ou gen laj legal pou fòme yon
+    LWA,
+    KONTRA AK PCI, E (3) OU GEN OTORITE POU ANTRE NAN RÈGLEMAN ITILIZASYON YO.<strong> SI OU PA
+      AKSPTE
+      REGLEMAN ITILIZASYON YO OU PA KA AKSEDE NI SÈVI AK APLIKASYON AN.<br>
+    </strong>
+  </p>
+  <p>
+    <strong>Tanpri pran konsyans ke SEKSYON 13 nan akò sa a, ki anba a, gen ladan dispozisyon ki
+      konfere ki jan depandans ke youn ak lot yo ka rezoud, ki enkli, san limit, nenpòt dispit ki
+      leve
+      oswa ki te asire anvan dat efikas nan akò sa a. An patikilye, li genyen yon akò abitraj ki
+      prale
+      avèk eksepsyon limite konfli antre nou ki dwe soumèt bay lyen ak abitraj final lan. A MWEN KE
+      OU
+      SOTI NAN ABITRAJ AKÒ A: (1) OU AP PÈMEN SÈLMAN POU POUSWIV DISPIt OU REKLAMASYON AK REVIZYON
+      KONT NOU SOU YON BAZ ENDIVIDYEL, PA KOM YON ASIRANS OSWA YON KLAS OU AKSYON REPREZANTAN OSWA
+      PWOSEDI; AK (2) OU ap renonse dwa ou nan pouswiv dispit oswa reklamasyon ak chèche jwenn
+      soulajman nan yon tribinal lwa epi yo gen yon JIRI PWOSÈ.<br>
+    </strong>
+  </p>
+  <p>
+    <strong>NENPOT DISPUTE, REKLAMASYON OU DEMANN POU RELYE RELASYON AN NENPOT MOUN KI POU ITILIZE
+      APLIKASYON W AP REGLE E INTERPRETE PA AK LWA NAN LWA ETA MASSACHUSETTS, ki konsistan avèk Lwa
+      sou Abitraj FEDERAL, SAN FONDEMAN bay nenpòt prinsip ki bay pou APLIKASYON LWA POU TOUT LOT
+      JURISDIKSYON an. KONVANSYON Nasyonzini an sou KONTRA POU VANN entènasyonal la nan machandiz yo
+      eksprime eksprè nan akò sa a.<br>
+    </strong>
+  </p>
+  <p>
+    TANPRI REMAKE KE AKÒ SA A SIJÈ POU CHANJE PA PCI NAN DISKRESYON NENPOT LÈ. Lè chanjman yo fèt,
+    PCI
+    pral fè yon nouvo kopi tèm itilizasyon ki disponib nan aplikasyon an. Nou pral tou mete ajou
+    "Dènye Mizajou" dat la nan tèt Regleman itilizasyon yo. Itilizasyon kontinyèl ou pou Aplikasyon
+    an
+    apre yon chanjman nan Regleman itilizasyon yo konstitye yon akseptasyon. Tanpri, tcheke
+    APLIKASYON
+    REGILYEMAN POU W WE KONDISYON ki pi aktyèl yo.<br>
+
+  </p>
+  <p>
+    <strong>1. ITILIZASYON APLIKASYON AN.</strong><br>
+    <strong>1.1 Definisyon</strong>. Menm jan nan Règleman itilizasyon yo, definisyon sa yo aplike:
+    <strong>"Itilizatè Aplikasyon"</strong> vle di yon moun natirèl moun ki te telechaje Aplikasyon
+    sou Regleman pou Itilize yo.<br>
+
+  </p>
+  <p>
+    <strong>"Lis lokalizasyon"</strong> vle di done kote ki kolekte nan aparèy mobil yon Itilizatè
+    Aplikasyon an pou jwenn GPS, Bluetooth ak / oswa lòt karakteristik oswa lojisyèl, ke itilizatè a
+    App chwazi yo te anrejistre epi estoke nan aplikasyon an enstale sou aparèy mobil itilizatè app
+    a.<br>
+
+  </p>
+  <p>
+    <strong>"Done Piblik ki disponib kote ke sekrize"</strong> vle di kat anonim nan kote piblik
+    kote
+    moun dyagnostike ak Covid-19 te vizite ak done dosye nan lè yo te vizite kote sa yo, konpile e
+    ki
+    te kreye pa yon twazyèm pati, epi yo te fè disponib atravè twazyèm pati nan twazyèm pati a Zòn
+    Santral App entènèt.<br>
+
+  </p>
+  <p>
+    <strong>"Safe Places lojisyèl"</strong> vle di louvri-sous lojisyèl, ki disponib nan <a
+       href="https://github.com/tripleblindmarkets/safe-places">https://github.com/tripleblindmarkets/safe-places</a>
+    , ki fasilite kontakte tras ak travay ki gen rapò, epi ki fèt pou itilize pa twazyèm pati,
+    tankou
+    ajans gouvènman an. <br>
+
+  </p>
+  <p>
+    <strong>"Twazyèm Pati Safe Places Web App"</strong> vle di yon aplikasyon ki baze sou wèb ki
+    posede ak opere pa yon twazyèm pati, tankou yon ajans gouvènman an, ki anplwaye Safe Places
+    lojisyèl, pami lòt bagay, pibliye Done Piblik Disponib Kote yo .<br>
+
+  </p>
+  <p>
+    <strong>1.2 Karakteristik aplikasyon ak fonksyonalite.</strong> Aplikasyon an fèt pou pèmèt
+    Itilizatè App, nan opsyon yo: (a) pou anrejistre lis lokalizasyon yo epi pou konsève done sa yo
+    lokalman nan Aplikasyon an, telechaje nan aparèy mobil yo, (b) pou jwenn aksè nan kote ki
+    disponib
+    yo piblikman nan yonn oswa plis Twazyèm Pati san Patipri Sit Entènèt Apps ak telechaje li nan
+    Safe
+    Paths App yo telechaje sou aparèy mobil yo, ak (c) yo pataje ki estoke yo lis lokalizasyon ak
+    twazyèm pati ke yo chwazi.<br>
+
+  </p>
+  <p>
+    <strong>1.3 Lisans aplikasyon an.</strong> Aplikasyon an ak enfòmasyon an ak kontni ki disponib
+    ladan l 'yo pwoteje pa lwa sou copyright nan tout mond lan. Sijè a an konfòmite avèk Akò sa a,
+    PCI
+    ba ou yon lisans limite ki pa exklizif, ki pa transfere, ki pa soulisansye, revokab pou
+    telechaje,
+    enstale epi sèvi ak yon kopi Aplikasyon an sou yon sèl aparèy mobil oswa òdinatè ke ou posede
+    oswa
+    kontwole e itlize tankou yon kopi aplikasyon an sèlman pou pwòp zafè pèsonèl ou oswa biznis.
+    Sèten
+    konpozan oswa bibliyotèk ki enkli oswa ki mete ansanm avèk Aplikasyon an konstitye lojisyèl sous
+    epi yo gen lisans anba lisans sous louvri. Nan limit ki egzije lisans sous yo, kondisyon ki nan
+    lisans sa yo ap aplike nan plas kondisyon ki nan Seksyon sa a 1.3, sèlman ki gen rapò ak sa yo
+    konpozan oswa bibliyotèk ki gen lisans anba lisans sous. Pou yon kopi lisans sous sa yo, vizite
+    <a
+       href="https://github.com/tripleblindmarketc/covid-safe-paths/blob/develop/LICENSE">https://github.com/tripleblindmarketc/covid-safe-paths/blob/develop/LICENSE</a>
+    . Anplis de sa, ki gen rapò ak nenpòt ki aplikasyon jwenn aksè nan oswa telechaje nan magazen an
+    App Apple (yon<strong> "App Store Sourced Aplikasyon"</strong>), ou pral sèlman itilize App
+    Store
+    Sourcing Aplikasyon an (a) sou yon pwodwi Apple ki mak ki iOS la (Apple la sistèm operasyon
+    propriétaires) ak (b) jan sa pèmèt nan "lwa Règleman yo" etabli nan kondisyon ki nan Apple la
+    Store App. Malgre premye fraz la nan seksyon sa a, ki gen rapò ak nenpòt ki Aplikasyon jwenn
+    aksè
+    a oswa telechaje soti nan magazen an Google Play (yon <strong>"Google Play Sourcing
+      Aplikasyon"</strong>), ou ka gen dwa lisans adisyonèl ki gen rapò ak itilize nan Aplikasyon an
+    sou yon baz pataje nan gwoup fanmi ou deziyen an.
+  </p>
+  <p>
+    <strong>1.4 Updates</strong>. Ou konprann ke pou kenbe Aplikasyon an pi itil pou Itilizatè App
+    ak
+    akomode fikse ensèk ak lòt chanjman teknolojik, PCI ka fè mizajou nan Aplikasyon an apre ou fin
+    telechaje Aplikasyon an. Mizajou sa yo ap disponib pou Itilizatè App yo nan men twazyèm pati ki
+    soti nan ki moun ou te resevwa lisans Aplikasyon an, eg, Apple App Store oswa Google Play (chak,
+    yon <strong>"App Store"</strong>). Ou pral gen kapasite a, nan opsyon ou a, download nenpòt ki
+    dènye nouvèl sou aplikasyon an ke nou fè lib disponib nan chanèl sa yo. Nou pa mande pou ou
+    enstale nenpòt ki dènye enfòmasyon yo nan lòd pou ou pou w kontinye lè l sèvi avèk Aplikasyon an
+    apre nou fè dènye enfòmasyon sa yo disponib. Sa a se paske nou pa kenbe okenn enfòmasyon sou ou
+    lè
+    ou telechaje Aplikasyon an. Se poutèt sa, nou pa pral konnen si ou te enstale nenpòt ki dènye
+    nouvèl sa yo. An konsekans, ou rekonèt epi mwen dakò ke si ou chwazi pa enstale dènye disponib,
+    Aplikasyon an pa pouvwa opere an akò ak dokiman piblik ki disponib konsènan karakteristik yo ak
+    fonksyonalite nan aplikasyon an, ki dokiman yo ka mete ajou apre tan ou te telechaje li orijinal
+    la. Anplis de sa, ou ka bezwen mete ajou lojisyèl twazyèm-pati de tan zan tan yo nan lòd yo sèvi
+    ak aplikasyon an. Nenpòt dènye emèt pa PCI ak enstale pa ou yo dwe jije aplikasyon an epi yo dwe
+    gouvène pa sa a Safe Places EULA oswa nenpòt ki apre akò lisans itilizatè fen akonpaye
+    aktyalizasyon la.
+  </p>
+  <p>
+    <strong>1.5 Ekipman ki nesesè yo ak lojisyèl.</strong> Ou dwe bay tout ekipman ak lojisyèl ki
+    nesesè pou telechaje epi itilize Aplikasyon an epi pou konekte ak sèvis oswa sit twazyèm pati,
+    ki
+    enkli men pa limite a, yon aparèy mobil ki apwopriye pou konekte ak aplikasyon an. Ou se sèl
+    responsab pou nenpòt frè, ki gen ladan koneksyon entènèt oswa frè mobil, ke ou antrene lè aksè
+    nan
+    aplikasyon an.
+  </p>
+  <p>
+    <strong>1.6 Responsablite pou lis lokaizasyon ak Lòt Done Kolekte ak ki estoke pa Ou.</strong>
+    PCI
+    pa gen okenn aksè a Kote Istwa a oswa nenpòt ki lòt done ou kolekte, resevwa ak magazen nan
+    aplikasyon an enstale oswa otreman sou aparèy mobil ou. Se poutèt sa, PCI pa gen okenn
+    responsablite pou sipresyon an oswa presizyon nan Istwa Kote a oswa lòt done ou kolekte, resevwa
+    oswa magazen nan aplikasyon an oswa echèk la nan magazen, transmèt oswa resevwa transmisyon nan
+    Istwa Kote oswa lòt done; oswa sekirite, konfidansyalite, depo, oswa transmisyon lòt
+    kominikasyon
+    ki soti nan oswa ki enplike itilizasyon aplikasyon an.<br>
+
+  </p>
+  <p>
+    <strong>2. Pwofesyonèl.</strong>
+  </p>
+  <p>
+    <strong>2.1 Aplikasyon.</strong> Eksepte sa ki gen rapò ak lis lokalizasyon ou ak lòt done ou ka
+    kolekte, rekipere soti nan twazyèm pati ak magazen nan aplikasyon an sou aparèy ou an, ou dakò
+    ke
+    PCI ak founisè li yo posede tout dwa, tit ak enterè nan ak aplikasyon an. Ou pa pral retire,
+    chanje oswa fènwa nenpòt copyright, mak komèsyal, mak sèvis oswa lòt dwa propriétaires avi
+    enkòpore nan oswa akonpaye Aplikasyon an.
+  </p>
+  <p>
+    <strong>2.2 Mak yo</strong>. Chase kowona ‘Safe paths’ COVID ak tout grafik ki konekte, logo,
+    mak
+    sèvis ak non komès yo itilize sou oswa an koneksyon avèk Aplikasyon an oswa an koneksyon avèk li
+    yo se mak komèsyal yo nan psi epi yo pa kapab itilize san pèmisyon an koneksyon avèk ou, oswa
+    nenpòt ki twazyèm-pati, pwodwi oswa sèvis. Lòt mak, mak sèvis ak non komès ki ka parèt sou oswa
+    nan aplikasyon an se pwopriyete pwopriyetè respektif yo.
+  </p>
+  <p>
+    <strong>3. KOLEKSYON AK ITILIZASYON ENFOMASYON PÈSONÈL OU.</strong> Ou rekonèt ke aplikasyon an
+    ka
+    kolekte enfòmasyon pèsonèl sou ou (nan chwa ou nan magazen enfòmasyon nan aplikasyon an oswa
+    atravè zouti teknoloji otomatik), ki gen ladan Istwa Kote ou. Ou rekonèt ke aplikasyon an ka ba
+    ou
+    opòtinite pou pataje enfòmasyon pèsonèl sou tèt ou, ki gen ladan Istwa Kote ou ak lòt moun. Tout
+    enfòmasyon pèsonèl an koneksyon avèk aplikasyon sa a sijè a règleman sou enfòmasyon prive nou
+    an.
+    Pa Téléchargez, enstale, lè l sèvi avèk, ak bay enfòmasyon pèsonèl nan oswa atravè aplikasyon sa
+    a, ou bay konsantman pou tout aksyon nou pran ki gen rapò ak enfòmasyon pèsonèl ou an konfòmite
+    ak
+    Règleman sou enfòmasyon prive. Pou kèk karakteristik nan aplikasyon an, konsantman espesifik ki
+    nesesè. Anplis de sa, ou ka chwazi divilge, nan lòt mwayen ki pa asosye avèk Aplikasyon an,
+    nenpòt
+    ki pati nan enfòmasyon pèsonèl ou a manm fanmi, doktè, founisè swen sante, ajans gouvènman, oswa
+    lòt moun oswa antite. Nou rekòmande ke ou fè chwa ou konsènan pataje enfòmasyon pèsonèl ou, nan
+    aplikasyon an oswa otreman, ak anpil atansyon. Nou pa pral gen okenn responsablite pou nenpòt
+    konsekans ki ka lakòz paske ou te lage oswa pataje enfòmasyon, nan Aplikasyon an oswa otreman,
+    ak
+    yon twazyèm pati.
+  </p>
+  <p>
+    <strong>4. REAKSYON</strong>. Si ou bay psi ak nenpòt ide, sijesyon, dokiman, ak / oswa
+    pwopozisyon (<strong>"Feedback"</strong>) via imel oswa yon lòt vle di, ou fè sa sou pwòp risk
+    ou,
+    epi ou rekonèt epi mwen dakò ke PCI pa gen okenn obligasyon (ki gen ladan san obligasyon limite
+    nan ... konfidansyalite) ki gen rapò ak sa yo Feedback. Ou reprezante ak garanti ke ou gen tout
+    dwa nesesè yo soumèt Feedback la. Se konsa, ou bay yon PCI yon konplètman peye, wayote-gratis,
+    tout tan, ki paka chanje, atravè lemond, ki pa san konte, ak konplètman sublicensable dwa ak
+    lisans yo sèvi ak, repwodui, fè, montre, distribye, adapte, modifye, re-fòma, kreye derive
+    travay
+    nan, ak otreman komèsyal oswa ki pa komèsyal esplwate nan nenpòt fason, nenpòt ak tout Feedback,
+    ak sublisans dwa ki ekri pi wo yo, an koneksyon avèk operasyon an ak antretyen nan aplikasyon
+    an,
+    nenpòt ki lòt pwodwi psi oswa sèvis, oswa biznis pci la.
+  </p>
+  <p>
+    <strong>5. Magazen APP.</strong> Ou rekonèt epi mwen dakò ke disponiblite Aplikasyon an depann
+    de
+    magazen App a ki moun ou te resevwa lisans aplikasyon an. Ou rekonèt ke Akò sa a se ant oumenm
+    ak
+    PCI epi yo pa avèk App Store la. Psi, pa App Store la, se sèl responsab pou Aplikasyon an, ki
+    gen
+    ladan kontni an psi ki disponib ladan l ', ak antretyen, sèvis sipò yo, ak garanti pou sa, ak
+    adrese nenpòt reklamasyon ki gen rapò ak sa yo (egzanp, responsablite pwodwi, konfòmite legal
+    oswa
+    pwopriyete entelektyèl. vyolasyon). Yo nan lòd yo itilize aplikasyon an, ou dwe gen aksè a yon
+    rezo san fil, epi ou dakò yo peye tout frè ki asosye ak aksè sa yo. Ou dakò tou pou peye tout
+    frè
+    yo (si genyen) ki akize nan magazen app a an koneksyon avèk aplikasyon an. Ou dakò konfòme ou
+    avèk, ak lisans ou yo sèvi ak aplikasyon an se kondisyone sou konfòmite ou avèk tout kondisyon
+    nan
+    akò enpoze pa App Store aplikab la lè w ap itilize aplikasyon an. Ou rekonèt ke magazen an App
+    (ak
+    filiales li yo) yo se benefisyè twazyèm pati nan akò sa a epi yo pral gen dwa aplike li.
+  </p>
+  <p>
+    <strong>6. FRÈ.</strong> Pa gen frè yo dwe peyab anba akò sa a pou dwa yo akòde anba akò sa a.
+    Ou
+    rekonèt epi mwen dakò ke aranjman frè sa a fèt an konsiderasyon pou alyans mityèl ki tabli nan
+    Akò
+    sa a, ki gen ladan obligasyon ou genyen anba la a, ak avètisman yo, esklizyon yo, ak limit
+    responsablite ki prezante nan dokiman sa a.
+  </p>
+  <p>
+    <strong>7. ENDEMNIFICASYON.</strong> Ou dakò dedomaje epi kenbe psi, paran li yo, filiales,
+    afilye, ofisye, anplwaye, volontè, ajan, patnè, founisè, ak lisans (chak, yon "PCI Pati" ak
+    kolektivman, "PCI Pati yo") inonsan nan nenpòt ki pèt. , depans, dèt ak depans (ki gen ladan frè
+    avoka rezonab) ki gen rapò ak oswa ki rive soti nan nenpòt ak tout bagay sa yo: (a) itilize ou
+    nan, oswa enkapasite yo sèvi ak aplikasyon an; (b) vyolasyon ou nan Kontra sa-a; (c) vyolasyon
+    ou
+    nan nenpòt ki dwa nan yon lòt pati; oswa (d) vyolasyon ou nan nenpòt lwa, règleman oswa règleman
+    ki aplikab yo. Psi rezève dwa pou, nan pwòp depans li yo, pou asime defans san konte ak kontwòl
+    sou nenpòt pwoblèm otreman sijè a dediksyon pa ou, nan ki evènman ou pral konplètman kolabore ak
+    psi nan revandike nenpòt defans ki disponib. Dispozisyon sa a pa egzije ou dedomaje nenpòt nan
+    Pati yo PCI pou nenpòt ki pratik komèsyal ki pa abizyon pa pati sa a oswa pou fwod pati sa a,
+    desepsyon, fo pwomès, bay manti oswa kache, repwesyon oswa omisyon nan nenpòt ki reyalite
+    materyèl
+    an koneksyon avèk aplikasyon yo bay la anba. . Ou dakò ke dispozisyon ki nan seksyon sa a ap
+    siviv
+    nenpòt ki revokasyon akò sa a ak / oswa ou itilize oubyen ou aksede a aplikasyon an.
+  </p>
+  <p>
+    <strong>8. Esklizyon garanti ak kondisyon</strong>
+  </p>
+  <p>
+    <strong>8.1 </strong>Konsa. OU DWE KONPRANN AK dakò POU PWOBLÈM APLIKAB, APLIKASYON OU NAN
+    APLIKASYON OU SE YO NAN RISK SÈL OU, AK APLIKASYON YO DISPONTE NAN YO "jan sa ye" ak "jan sa
+    disponib", avèk tout peche. Pati ki PCI EXPRESSLY DISI RESPONSABLOU tout garanti,
+    REPREZANTASYON,
+    ak kondisyon nan nenpòt kalite, menm si yo eksprime oswa enplike, ki gen ladan, men PA limite a,
+    GARANTI IMPLIYE OSWA kondisyon yo ki nan komès, fòm pou yon bi patikilye ak ki pa vyolasyon ki
+    soti nan itilizasyon APLIKASYON.
+  </p>
+  <p>
+    <strong>(a) </strong> PATI yo PCI pa fè okenn garanti, reprezantasyon oswa kondisyon ke: (1)
+    APLIKASYON la oswa karakteristik li yo ap satisfè egzijans ou; (2) ITILIZASYON OU NAN APLIKASYON
+    AN YO PAP KONTINYE, PWOPRIYE, SEKIRITE OUBYE ERÈ GRATIS; OSWA (3) REZILTA YO KI JWENN PWOCHE NAN
+    ITILIZASYON APLIKASYON AN YO KAP FÈ OU FYAB.
+  </p>
+  <p>
+    <strong>(b) </strong>Nenpòt kontni ki soti nan oswa ki aksesib pa mwayen aplikasyon an aksè nan
+    pèt pwòp ou a, epi ou dwe toujou fè responsablite pou nenpòt ki domaj nan pwopriyete w, ki gen
+    ladan, men li pa limite a, sistèm konpitè ou ak nenpòt aparèy ou sèvi pou jwenn aksè nan
+    aplikasyon an, OSWA NENPOT L THT PÈDI KI REZILTAJ Soti nan aksè nan kontni sa yo.
+  </p>
+  <p>
+    <strong>(c) </strong>Disponibilite pou aplikasyon an ak karakteristik li yo ka sijè a reta,
+    anilasyon ak lòt pyès lajan. Psi pa fè okenn garanti, REPREZANTASYON oswa kondisyon sou respè
+    APLIKASYON an oswa karakteristik li yo, ki gen ladan men li pa limite a, kalite, efikasite,
+    repitasyon ak lòt karakteristik sa yo.
+  </p>
+  <p>
+    <strong>(d) </strong>Pa gen konsèy oswa ENF ,MASYON, kèlkeswa ORAL oswa EKRI, jwenn soti nan psi
+    oswa atravè aplikasyon an pral kreye nenpòt GARANTI pa eksprime fè HEREIN.
+  </p>
+  <p>
+    <strong>(e) </strong>Soti nan tan pou tan, PCI ka ofri nouvo "BETA" karakteristik oswa zouti ak
+    ki
+    moun ki itilizatè li yo ka eksperyans. Karakteristik sa yo oswa zouti yo ofri sèlman pou
+    objektif
+    eksperimantal ak san okenn garanti nenpòt ki kalite, e yo ka modifye oswa rete nan DISKRÈS SÈL
+    PCI
+    a. DISPOZISYON YO SEKSYON SA A APLIKE AK TOUT FS POU Karakteristik sa yo oswa zouti.
+  </p>
+  <p>
+    <strong>8.2 PA ENPTE POU KONSÈY MEDIKAL.</strong> Ou rekonesan ke ENFORMASYON SOU APLIKASYON AN
+    FÈ
+    POU FÈ YO POU FINANS ENFOMASYON JENERAL SÈLMAN. Li pa konsantre kòm yon konsèy MEDIKAL sou
+    nenpòt
+    ki kalite TIMOUN OSYO li se entansyon DYAGNOSE, trete, geri oswa anpeche okenn maladi oswa
+    kondisyon medikal. ENFMASYON SOU PREZIDAN NAN APLIKASYON AN PA DWE INTERPRETE OUBYEN KONSTWI NAN
+    NENPT fason ke yon ranplasman oswa yon sèvis konsèy medikal ki founi pa doktè w oswa lòt founisè
+    swen sante ki kalifye. OU PA DWE DISREGARDE, EVITE OUBYEN RETE NAN OBTIEN MEDIKAL KONSÈY OSWA
+    TRETMAN SOU DOKTÈ OU OUBYEN L QUT KALIFYE HEALTHCARE PROVIDER POU TOUT ENFMASYON SOU APLIKASYON.
+    SOU pa gen sikonstans ou ta dwe chanje tretman medikal egziste ou, medikaman REGIMEN, oswa
+    nenpòt
+    ki lòt aktivite sante ki gen rapò ki baze sou nenpòt ki enfòmasyon ki bay nan aplikasyon an. Li
+    ENP FORTAN POU OU DISKITE OPSYON TRETMAN OU, AK NENPS KESYON KI OU GENYEN, AVÈK DOKTÈ OUBYEN
+    OUBYEN L QUT LWA SOU KALIFYE SANTE.<br>
+
+  </p>
+  <p>
+    <strong>8.3 </strong>Nan fè aplikasyon an ki disponib pou download, objektif PCI a se bay moun
+    ki
+    gen yon zouti itil pou kontakte tras. Sepandan, sèvis piblik la nan karakteristik Aplikasyon an
+    se
+    depann sou yon kantite faktè ki deyò kontwòl la psi, tankou fyab la nan GPS detèktè, si wi ou
+    non
+    moun yo ap pote aparèy mobil yo, menm jan tou presizyon, disponiblite, disponiblite, efikasite.
+    oswa itilize kòrèk la nan aparèy mobil moun nan ak GPS detèktè, tout nan yo ki yo te itilize yo
+    kreye Istwa Kote, ak pou nenpòt ki Piblikman disponib Kote kote Done ke ou ka Upload nan
+    aplikasyon ou soti nan sous twazyèm pati, presizyon an ak konplè nan done sa yo. Istwa Kote ou
+    oswa lòt done ka disponib, kòrèk oswa enkonplè. Sèvi ak aplikasyon an pa ta dwe ranplase bon
+    jijman ou ak sans komen.
+  </p>
+  <p>
+    <strong>8.4 Pa gen Responsablite pou Konduit nan twazyèm pati yo.</strong> Ou rekonesan epi
+    aksepte ke pati PCI yo pa responsab, epi ou dakò pa chèche kenbe Psi pati yo responsab, pou
+    kondwit la oswa omisyon nan twazyèm pati, ki gen ladan aksyon yo ki nan nenpòt ki twazyèm pati
+    opere yon sit entènèt kote ki gen twazyèm pati oswa nenpòt gouvènman an. AJANS AVÈK OU CHWAZI
+    POU
+    INTERRÈT SOU ITILIZASYON AK ITILIZASYON OU NAN APLIKASYON OU, AK KI RISK BAGAY KI SOTI NAN TÈS
+    PARTI YO, RETE AK OU.<br>
+
+  </p>
+  <p>
+    <strong>9. LIMITASYON RESPONSABLITE.</strong>
+  </p>
+  <p>
+    <strong>1.1</strong> Limit responsabilite nou de sèten domaj. OU KONPRANN AK dakò KI PA GEN
+    EVÈNMAN PATI pati PCI YON RESPONSAB POU NENPT PÈS POU PROFIT, BLIJI PÈSONÈL, DANJE PWOPRIYETE,
+    MOVE MALADI, ENFMASYON OSWA DONE, DANI INDIRÈT, ENSIDANS, ESPESYAL, OSWA DWA, OSWA DANYE oswa
+    domaj OSWA KOTE POU Pèdi yo. PWODIKSYON OSWA ITILIZASYON, ENTRETISYON BIZNIS, KONTAKTE OU SÈVIS
+    SE
+    YON SÈVIS, NAN CHAK KASYE OU SÈLMAN PCI YO te AVÈVRE POU POSIBILITE DAN, KONTINYE NAN OU
+    KONNEKSYON AVÈK AKANSYON, NAN NENPT TEWO KI RESPONSABILITE, REZILTE Soti nan : (1) itilizasyon
+    an
+    oswa inabilite pou itilize aplikasyon an oswa nenpòt nan karakteristik li yo piblisite; (2) AKSE
+    NAN OTORIZE POU OU oswa modifikasyon nan transmisyon OU oswa DONE; OUBYEN (3) NENPT LT KESYON KI
+    KONSÈNE APLIKASYON AN, OU SOU BAZE SOU GARANTI, DWA KONTRA, KONTRA, TRIBE (KI GEN NÉLIGENCE),
+    OSWA
+    NENPT L .T TEORI LEGAL. NAN PWOCHEN AN PREZAN SOU RESPONSABLITE PAP APLIKE POU RESPONSABLITE YON
+    PAPI PAPI POU (A) LANM OSWA KIJE PÈSONÈL KI FÈ PANDAN PANDAN PATI yon pati PIKI; OSWA POU (B)
+    Nenpòt blesi ki te koze pa yon fwis PCI pati a oswa yon fo reprezantasyon FRAUDULENT.<br>
+
+  </p>
+  <p>
+    <strong>1.2 </strong>Kap sou Responsabilite. POU PWOJÈ maksimòm PEMISYE POU LWA, KI KOTE POU
+    NENPAY NENPOT POU KONTW CONCH KI GENYEN LA, RESPONSABLITE NOU POU OU pou nenpòt domaj ki soti
+    nan
+    oswa ki gen rapò ak kondisyon sa yo pou itilize (pou nenpòt ki koz toutbon menm jan ak fòm nan
+    AKSYON an), yo pral nan tout. Kantite tan yo limite a yon maksimòm de senk DOLARS US (US $ 50).
+    Egzistans plis pase yon sèl reklamasyon p ap elaji limit sa a. Ou dakò ke founisè nou yo p ap
+    gen
+    okenn responsablite nenpòt ki kalite ki sòti nan oswa ki gen rapò ak kondisyon sa yo sèvi
+    ak.<br>
+
+  </p>
+  <p>
+    <strong>1.3 </strong>Done ou. EKSEPTE pou OBLIGASYON PCI a PWOTEJE DONE PÈSONÈL OU jan li te
+    etabli nan règleman prive PCI a, PCI sipoze pa gen okenn responsablite pou tan an, DELETION,
+    MIS-livrezon oswa echèk magazen nenpòt ki kontni (ki enkli istwa lokasyon ou), itilizatè
+    kominikasyon oswa anviwònman pèsonalizasyon.<br>
+
+  </p>
+  <p>
+    <strong>1.4 </strong> Baz negosyasyon an. Limit nan domaj ki etabli anwo yo se eleman
+    fondamantal
+    de baz la nan PAPA ant PCI ak ou.
+  </p>
+  <p>
+    <strong>2. KONSÈY.</strong>
+  </p>
+  <p>
+    <strong>2.1 Vyolasyon</strong>. Si PCI vin okouran nenpòt vyolasyon posib ke ou nan Akò sa a,
+    PCI
+    rezève dwa pou envestige vyolasyon sa yo. Si, kòm yon rezilta nan ankèt la, psi kwè ke gen
+    aktivite kriminèl ki te fèt, PCI rezève dwa pou refere ka a, epi pou kolabore ak, nenpòt ak tout
+    otorite legal ki aplikab yo. PCI gen dwa, eksepte nan limit ki entèdi nan lalwa aplikab, divilge
+    nenpòt enfòmasyon oswa materyèl ou bay PCI an koneksyon avèk itilizasyon ou nan Aplikasyon an,
+    nan
+    (a) konfòme ou avèk lwa aplikab, pwosesis legal oswa demann gouvènman an; (B) ranfòse sa yo
+    Regleman pou Itilize, (c) reponn a demann ou an pou sèvis kliyan, oswa (d) pwoteje dwa yo,
+    pwopriyete oswa sekirite pèsonèl nan psi oswa piblik la, ak tout ranfòsman oswa lòt ofisyèl
+    gouvènman yo, kòm psi, nan. sèl diskresyon li kwè ke li nesesè oswa apwopriye.<br>
+
+  </p>
+  <p>
+    <strong>3. Regleman ak sispansyon.</strong>
+  </p>
+  <p>
+    <br>
+    <strong>3.1 Regleman. </strong>Akò sa a kòmanse nan dat la lè ou aksepte yo (jan sa dekri nan
+    pre-an pi wo a) epi rete nan tout fòs ak efè pandan w ap itilize aplikasyon an, sòf si sispann
+    pi
+    bonè nan akò ak sa a Akò.<br>
+
+  </p>
+  <p>
+    <strong>3.2 Itilize Anvan.</strong> Malgre sa ki endike anwo la a, ou rekonèt epi mwen dakò ke
+    Akò
+    sa a te kòmanse nan pi bonè pou rive nan (a) dat ou te itilize Aplikasyon an oswa (b) dat ou te
+    aksepte Kontra sa a epi w ap rete nan tout fòs ou pandan wap itilize. Aplikasyon an, sòf si li
+    te
+    sispann pi bonè dapre Akò sa a.<br>
+
+  </p>
+  <p>
+    <strong>3.3 Revokasyon ou.</strong> Si ou vle mete fen nan Akò sa a, ou ka fè sa pa efase
+    aplikasyon an soti nan aparèy mobil ou.<br>
+
+  </p>
+  <p>
+    <strong>3.4 Efè Termination</strong>. Fen nan akò sa a egzije pou ou efase aplikasyon an ak
+    sispann tout itilize nan li. Tout dispozisyon ki nan akò sa a ki pa nati yo ta dwe siviv, va
+    siviv
+    mete fen, ki gen ladan san limit, dispozisyon pwopriyetè, avètisman garanti, ak limitasyon de
+    responsablite.
+  </p>
+  <p>
+    <strong>4. Itilizatè entènasyonal yo.</strong> Aplikasyon an fèt sèlman pou itilize nan Etazini
+    nan Amerik la. Psi pa fè okenn reprezantasyon ki aplikasyon an fonksyonèl nan lòt kote. Moun ki
+    gen aksè oswa ki itilize aplikasyon an nan lòt peyi yo fè sa sou pwòp risk yo epi yo responsab
+    pou
+    itilize an konfòmite ak lwa lokal yo.<br>
+
+  </p>
+  <p>
+    <strong>5. Rezolisyon dispit.</strong> Tanpri li akò arbitraj sa a nan Seksyon sa a ("Akò
+    Abitraj") avèk anpil atansyon. Li mande pou itilizatè Ameriken abitraj diskisyon avèk psi epi
+    limite fason ou ka chèche sekou nan men nou.<br>
+
+  </p>
+  <p>
+    <strong>5.1 Aplikablite nan Abitraj Akò.</strong> Ou dakò ke nenpòt dispit, reklamasyon, oswa
+    demann pou soulajman ki gen rapò nan nenpòt fason pou aksè ou oswa pou sèvi ak aplikasyon an
+    oswa
+    nan nenpòt ki aspè nan relasyon ou ak psi, yo pral rezoud pa abitraj obligatwa, olye ke nan
+    tribinal, eksepte ke (1 ) ou ka revandike reklamasyon oswa chèche sekou nan tribinal ti
+    reklamasyon si reklamasyon ou kalifye; epi (2) ou oswa PCI ka chèche soulajman ekitab nan
+    tribinal
+    pou vyolasyon oswa lòt move itilizasyon nan dwa pwopriyete entelektyèl (tankou mak, rad komès,
+    non
+    domèn, sekrè komès, copyright, ak rive). Akò sou Abitraj sa a dwe aplike, san limitasyon, nan
+    tout
+    diskisyon oswa reklamasyon ak demann pou soulajman ki leve oswa yo te pwoklame anvan dat efektif
+    akò sa a oswa nenpòt vèsyon anvan akò sa a.<br>
+
+  </p>
+  <p>
+    <strong>5.2 Règ Abitraj ak Forum.</strong> Lwa sou Abitraj Federal la gouvène entèpretasyon ak
+    ranfòsman akò sa a sou Abitraj. Pou kòmanse yon pwosedi abitraj, ou dwe voye yon lèt pou mande
+    abitraj epi dekri konfli ou oswa reklamasyon ou oswa demann soulajman pou ajan ki anrejistre nou
+    an, Samuel Hoff c / o Pierce & Mandell, P.C. 11 Beacon Street Suite 800, Boston MA 02108. JAMS,
+    yon founisè etabli altènatif pou rezoud dispit la, ap fè abitraj la. Konfli ki konsène
+    reklamasyon, rekou, oswa demann pou soulajman ki poko gen $ 250,000, ki pa enklizif nan avoka ak
+    frè ak enterè, va sijè a vèsyon JAMS ki pi resan nan Règ akize Abitraj ak pwosedi ki disponib
+    nan
+    http://www.jamsadr.com/rules -abri-abinis /; tout lòt diskisyon yo pral sijè a JAMS a vèsyon ki
+    pi
+    aktyèl la nan règleman yo ak pwosedi Abitraj Comprehensive, ki disponib nan
+    http://www.jamsadr.com/rules-comprehensive-arbitration/. Règ JAMS a yo disponib tou nan
+    www.jamsadr.com oswa lè w rele JAMS nan 800-352-5267. Si JAMS pa disponib pou arbit, pati yo ap
+    chwazi yon fowòm altènatif arbit. Si medyatè a jwenn ke ou pa kapab peye depozisyon JAMS yo,
+    administratif, odyans ak / oswa lòt frè epi yo pa ka jwenn yon egzansyon nan JAMS, PCI pral peye
+    yo pou ou. Anplis de sa, PCI ap ranbouse tout depozisyon JAMS a, administratif, odyans ak / oswa
+    lòt frè pou diskisyon, reklamasyon, oswa demann pou sekou total yon mwens pase $ 10,000 sòf si
+    medyatè a detèmine reklamasyon yo se serye.<br>
+
+  </p>
+  <p>
+    Ou ka chwazi fè abitasyon an fèt pa telefòn, ki baze sou soumèt alekri, oswa nan yon lòt yo te
+    dakò youn pou lòt. Nenpòt jijman sou prim lan bay nan medyatè a ka antre nan nenpòt ki tribinal
+    ki
+    gen konpetans jiridiksyon.<br>
+
+  </p>
+  <p>
+    <strong>5.3 Otorite nan abitrè.</strong> Medyatè a dwe gen otorite eksklizif pou (a) detèmine
+    sijè
+    ki abòde lan ak aplikabite nan Akò sa a Abitraj ak (b) rezoud nenpòt dispit ki gen rapò ak
+    entèpretasyon, aplikabilite, aplikab, oswa fòmasyon sa a Arbitraj Akò ki gen ladan, men pa
+    limite
+    a, nenpòt ki afirmasyon ki. tout oswa nenpòt ki pati nan akò sa a Abitraj anile oswa anile.
+    Abitraj la ap deside dwa ak responsablite, si genyen, ou menm ak PCI. Pwosedi abitraj la pa pral
+    konsolide ak nenpòt lòt zafè oswa ansanm ak nenpòt ki lòt ka oswa pati yo. Medyatè a dwe gen
+    otorite pou bay mosyon dispozisyon nan tout oswa yon pati nan nenpòt reklamasyon. Medyatè a dwe
+    gen otorite pou l akòde domaj monetè ak pou bay nenpòt moun ki pa monetè remèd oswa sekou
+    disponib
+    nan yon moun ki anba lwa aplikab, règleman yo forum la arbitro a, ak akò sa a (ki gen ladan Akò
+    a
+    Abitraj). Medyatè a dwe bay yon prim ekri ak yon deklarasyon sou desizyon ki dekri rezilta
+    esansyèl yo ak konklizyon sou ki prim lan ki baze, ki gen ladan kalkil la nan nenpòt ki domaj yo
+    bay la. Medyatè a gen menm otorite pou bay sekou nan yon baz endividyèl ke yon jij nan yon
+    tribinal la ta genyen. Prim nan medyatè a se final ak obligatwa pou ou ak pou nou.
+  </p>
+  <p>
+    <strong>5.4 Egzanpsyon pou jijman jiri.</strong> OU AK PCI SE RENSEYE KÈK DWA KONSTITISYONÈL AK
+    STATWA POU VOJE NAN TRIBINAL AK YON JIJANS AN devan yon Jij oswa yon jiri. Oumenm ak PCI se olye
+    pou chwazi tout diskisyon, reklamasyon, oswa demann pou soulajman yo dwe rezoud nan abitraj
+    dapre
+    Akò sou Abitraj sa a, eksepte jan sa endike nan Seksyon 13.1 anwo a. Yon medyatè kapab bay yon
+    baz
+    endividyèl menm domaj ak soulajman tankou yon tribinal epi li dwe swiv Kontra sa a kòm yon
+    tribinal ta. Sepandan, pa gen okenn jij oswa jiri nan abitraj, ak revizyon tribinal nan yon prim
+    abitraj se sijè a revizyon trè limite.<br>
+
+  </p>
+  <p>
+    <strong>5.5 Egzanpsyon pou Sekou Klas oswa Lòt ki pa Peye-endividyalize. </strong>Tout
+    diskisyon,
+    reklamasyon, ak Demann pou soulajman nan domèn AKIT ARBITRE sa a dwe abrite sou yon baz
+    endividyèl
+    epi yo pa sou yon klas oswa baz kolektif, SÈLMAN POU gen soulajman endividyèl, ak reklamasyon
+    nan
+    plis pase yon kliyan oswa itilizatè pa ka ARBITRE Oswa konsolide ak moun ki nan nenpòt ki lòt
+    kliyan oswa itilizatè. Si yo bay yon desizyon ki deklare ke lwa ki aplikab entèdi ranfòsman nan
+    nenpòt ki limit souseksyon sa a sou yon dispit bay, reklamasyon, oswa demann pou soulajman, Lè
+    sa
+    a, yo dwe aspè tankou separe nan abitraj la ak pote nan Eta a oswa Tribinal Federal ki sitiye
+    nan
+    la. Commonwealth nan Massachusetts. Tout lòt diskisyon, reklamasyon, oswa demann pou sekou yo
+    dwe
+    abitraj.<br>
+
+  </p>
+  <p>
+    <strong>5.6 Dwa 30-Jou yo chwazi pou soti.</strong> Ou gen dwa pou ou pa patisipe nan
+    dispozisyon
+    ki nan Kontra Abitraj sa a pa voye yon avi alekri sou desizyon ou a patisipe soti nan:
+    legal@pathcheck.org, nan lespas 30 jou apre premye vin sijè a sa a Abitraj Akò. Avi ou a dwe
+    enkli
+    non ou ak adrès ou, adrès imèl ou, ak yon deklarasyon inekivok ke ou vle patisipe nan Akò sa a
+    Abitraj. Si ou chwazi pou ou pa soti nan Abitraj sa a, tout lòt pati nan Akò sa a ap kontinye
+    aplike pou ou. Chwazi soti nan sa a Akò Abitraj pa gen okenn efè sou nenpòt ki lòt akò abitraj
+    ke
+    ou ka kounye a gen, oswa ka antre nan nan tan kap vini an, avèk nou.<br>
+
+  </p>
+  <p>
+    <strong>5.7 Divisibilite.</strong> Eksepte jan yo prevwa nan souseksyon 13.5, si nenpòt pati
+    oswa
+    pati nan akò sa a Abitraj yo te jwenn anba lalwa a yo dwe valab oswa ki pa ka ranfòse, Lè sa a,
+    tankou yon pati espesifik oswa pati va gen ki pa gen fòs ak efè epi yo pral koupe ak rès la nan
+    Abitraj la. Akò va kontinye nan fòs plen ak efè.<br>
+
+  </p>
+  <p>
+    <strong>5.8 Siviv nan Akò.</strong> Akò sa a Abitraj ap siviv mete fen nan relasyon ou a ak
+    psi.<br>
+
+  </p>
+  <p>
+    <strong>5.9 Modifikasyon. </strong>Malgre nenpòt dispozisyon ki nan Kontra sa-a nan kontrè a,
+    nou
+    dakò ke si PCI fè nenpòt ki chanjman materyèl nan lavni sa a Abitraj Akò, ou ka rejte ki
+    chanjman
+    nan trant (30) jou de chanjman sa yo vin efektif pa ekri PCI nan adrès sa a: Path Check, Inc. PO
+    Box 441621, Somerville, MA 02144<br>
+
+  </p>
+  <p>
+    <strong>6. DISPOZISYON JENERAL YO<br>
+    </strong>
+  </p>
+  <p>
+    <strong>6.1 Kominikasyon elektwonik.</strong> Kominikasyon ant ou menm ak PCI ka pran plas
+    atravè
+    mwayen elektwonik, si ou voye yon imèl PCI, oswa si PCI poste avi nan Aplikasyon an oswa atravè
+    mizajou yo te fè nan Aplikasyon an annakò avèk sa a Regleman pou Itilize oswa kominike avèk ou
+    via- lapòs. Pou rezon kontra, ou (a) konsanti pou resevwa kominikasyon soti nan psi nan yon fòm
+    elektwonik; ak (b) dakò ke tout tèm ak kondisyon, akò, avi, divilgasyon, ak lòt kominikasyon ke
+    psi bay ou elektwonikman satisfè nenpòt kondisyon legal ki kominikasyon sa yo ta satisfè si li
+    ta
+    dwe nan ekri. Pi wo la a pa afekte dwa legal ou, ki enkli men pa limite a Siyati Elektwonik nan
+    Lwa Global ak Komès Nasyonal nan 15 US.C. §7001 et seq. ("E-Siyen").<br>
+
+  </p>
+  <p>
+    <strong>6.2 Lansman.</strong> Ou fin divilge Pèmi yo PCI ak siksesè yo soti nan reklamasyon,
+    demand, nenpòt ak tout pèt, domaj, dwa, ak aksyon nenpòt kalite, ki gen ladan blesi pèsonèl,
+    lanmò, ak domaj pwopriyete, ki se swa dirèkteman oswa endirèkteman ki gen rapò ak oswa rive soti
+    nan nenpòt ki entèraksyon ak kondwit nan operatè nan Twazyèm Pati Safe Plas Entènèt Apps,
+    founisè
+    swen sante, ajans gouvènmantal, nan nenpòt kalite ki rive an koneksyon avèk oswa kòm yon rezilta
+    nan akò sa a oswa itilizasyon ou nan aplikasyon an. Si ou se yon rezidan nan Kalifòni, ou
+    renonse
+    California Seksyon Sivil Kòd 1542, ki deklare, "Yon lansman jeneral pa pwolonje nan reklamasyon
+    ke
+    kreyansye a oswa pati lansman pa konnen oswa sispèk egziste nan favè li oswa li nan moman sa a
+    nan
+    ... egzekite liberasyon an e ke, si li te konnen pa li oswa li, li ta gen materyèl afekte l'oswa
+    règleman li yo ak debiteur la oswa pati lansman." Lansman ki anwo la a pa aplike pou okenn
+    reklamasyon, demand, oswa nenpòt pèt, domaj, dwa ak aksyon nenpòt kalite, tankou blesi pèsonèl,
+    lanmò oswa pwopriyete domaj pou nenpòt ki pratik komèsyal abi pou yon PCI Pati oswa pou fwod
+    pati
+    sa a, desepsyon, fo, pwomès, fo reprezantasyon oswa kache, repwesyon oswa omisyon nan nenpòt
+    reyalite materyèl an koneksyon avèk Aplikasyon an bay la anba a.
+  </p>
+  <p>
+    <strong>6.3 Plasman.</strong> Akò sa a, ak dwa ou yo ak obligasyon ki anba la a, pa ka asiyen,
+    soutretan, delege oswa otreman transfere pa ou san ou pa konsantman PCI anvan ekri, ak nenpòt
+    tantativ tantasyon, tretman, delegasyon, oswa transfè an vyolasyon sa ki ekri pi wo a pral nil
+    epi
+    yo anile. .
+  </p>
+  <p>
+    <strong>6.4 Fòs majè. </strong>PCI pa dwe responsab pou okenn reta oswa echèk nan fè rezilta ki
+    soti nan kòz deyò kontwòl rezonab li yo, ki gen ladan, men pa limite a, zak Bondye a, lagè,
+    teworis, revòlt, embargos, zak otorite sivil oswa militè, dife, inondasyon ,. aksidan, grèv oswa
+    mank fasilite transpò, gaz, enèji, travay oswa materyèl.
+  </p>
+  <p>
+    <strong>6.5 Kesyon, Plent, Reklamasyon.</strong> Si ou gen nenpòt kesyon, plent oswa reklamasyon
+    ki gen rapò ak Aplikasyon an, tanpri kontakte nou nan: <a
+       href="mailto:support@pathcheck.org">support@pathcheck.org</a>.
+  </p>
+  <p>
+    <strong>6.6 Eksklizif Venue.</strong> Nan mezi pati yo gen pèmisyon dapre Akò sa a pou kòmanse
+    yon
+    litij nan yon tribinal, tou de ou menm ak PCI dakò ke tout reklamasyon ak diskisyon ki rive soti
+    nan oswa ki gen rapò ak sa a Akò pral plede sèlman nan tribinal yo leta oswa federal ki sitiye
+    nan
+    Boston, Massachusetts.<br>
+
+  </p>
+  <p>
+    <strong>6.7 Lwa sou Gouvènman</strong> TÈM YO AK NENPT AKSYON KI KI TE RELIJE A ANREJE AK
+    INTERPRETE PA AK LWA NAN LWA COMMONWEALTH OF MASSACHUSETTS, ki konsistan avèk Lwa sou Arbitraj
+    FEDERAL, san bay efè sou nenpòt prensip ki bay APLIKASYON LWA POU YON LDT JURISDIKSYON.
+    KONVANSYON
+    Nasyonzini an sou KONTRA POU VANN entènasyonal la nan machandiz pa aplike pou akò sa a.
+  </p>
+  <p>
+    <strong>6.8 Chwa langaj.</strong> Li se vle eksprime pati yo ke Akò sa a ak tout dokiman ki gen
+    rapò ak yo te trase moute nan lang angle.
+  </p>
+  <p>
+    <strong>6.9 Avi. </strong>Ou ka remèt yon avi bay PCI nan adrès sa a: Path Check, Inc. PO Box
+    441621, Somerville MA 02144. Yo dwe konsidere yon avi konsa lè yo resevwa pa PCI pa yon lèt bay
+    pa
+    sèvis livrezon lannwit ke yo rekonèt nasyonalman oswa lapòs premye pòs klas pre-peye nan nan
+    adrès
+    ki pi wo a.
+  </p>
+  <p>
+    <strong>6.10 Renonsyasyon.</strong> Nenpòt egzanpsyon oswa echèk nan ranfòse nenpòt dispozisyon
+    nan kontra sa-a nan yon sèl okazyon pa pral jije yon egzansyon nan nenpòt ki lòt pwovizyon oswa
+    nan dispozisyon sa a sou nenpòt ki lòt okazyon.
+  </p>
+  <p>
+    <strong>6.11 Divisibilite</strong>. Si nenpòt pòsyon nan Kontra sa-a se fèt valab oswa ki pa
+    aplikab, yo dwe entèprete pòsyon sa a nan yon fason yo reflete, kòm prèske ke posib, entansyon
+    orijinal la nan pati yo, ak pòsyon ki rete yo ap rete nan tout fòs ak efè.
+  </p>
+  <p>
+    <strong>6.12 Ekspòtasyon kontwòl.</strong> Ou pa ka itilize, ekspòtasyon, enpòte, oswa transfere
+    Aplikasyon an eksepte jan otorize pa lalwa Etazini, lwa yo nan jiridiksyon an nan ki ou te jwenn
+    Pwopriyete PCI, ak nenpòt lòt lwa ki aplikab yo. An patikilye, men san limit, Aplikasyon an pa
+    ka
+    ekspòte oswa re-ekspòte (a) nan nenpòt peyi Etazini anbago, oswa (b) bay nenpòt moun ki sou lis
+    Depatman Trezò Ameriken yo ki deziyen espesyalman oswa Depatman Ameriken an nan komès la refize.
+    Lis Moun oswa Lis Antite yo. Lè l sèvi avèk Aplikasyon an, ou reprezante ak garanti ke (y) ou pa
+    sitiye nan yon peyi ki sijè a yon anbago gouvènman ameriken, oswa ki te deziyen pa gouvènman
+    ameriken an kòm yon peyi "teroris sipòte" ak (z) ou. yo pa nan lis nan okenn lis Gouvènman
+    ameriken nan pati entèdi oswa ki gen restriksyon. Ou pa pral itilize Aplikasyon an pou okenn
+    rezon
+    entèdi pa lwa Etazini, ki gen ladan devlopman, konsepsyon, fabrike oswa pwodiksyon de misil, zam
+    nikleyè, chimik oswa byolojik. Ou rekonèt ak dakò ke pwodwi, sèvis oswa teknoloji ki ofri pa psi
+    yo sijè a lwa yo kontwòl ekspòtasyon ak règleman nan peyi Etazini. Ou dwe konfòme w ak lwa sa yo
+    ak règleman epi yo pa dwe, san otorizasyon gouvènman Etazini, ekspòtasyon, re-ekspòtasyon, oswa
+    transfere pwodwi psi, sèvis oswa teknoloji, swa dirèkteman oswa endirèkteman, nan nenpòt ki peyi
+    an vyolasyon de lwa ak règleman sa yo.
+  </p>
+  <p>
+    <strong>6.13 Jwenn aksè ak telechaje aplikasyon an soti nan iTunes.</strong> Sa ki annapre yo
+    aplike a nenpòt ki App Store Sourcing Aplikasyon jwenn aksè a oswa telechaje soti nan Apple App
+    Store:
+  </p>
+  <ol>
+
+    <li>Ou rekonèt epi mwen dakò ke (mwen) se Akò sa a konkli ant ou menm ak PCI sèlman, epi yo pa
+      Apple, ak (ii) PCI, pa Apple, se sèl responsab pou App Store Sourcing Aplikasyon an ak kontni
+      ladan l '. Sèvi ak ou nan App Store Sourced Aplikasyon an dwe konfòme yo avèk Regleman yo App
+      Store nan Sèvis.
+    </li>
+  </ol>
+  <ol>
+
+    <li>Ou rekonèt ke Apple pa gen okenn obligasyon tou sa pou founi okenn sèvis antretyen ak respè
+      pou aplikasyon magazen App.<br>
+
+
+    <li>Nan evènman an nan nenpòt ki echèk nan App Store Sourcing Aplikasyon an konfòme yo ak nenpòt
+      ki aplikab garanti, ou ka avèti Apple, ak Apple ap ranbouse pri acha a pou App Store Sourcing
+      Aplikasyon an pou ou ak nan limit maksimòm nan lalwa aplikab, Apple. pa pral gen okenn
+      obligasyon lòt garanti tou sa ki gen rapò ak App Store Sourcing Aplikasyon an. Ant PCI ak
+      Apple,
+      nenpòt ki lòt reklamasyon, pèt, dèt, domaj, depans oswa depans atribuabl a nenpòt ki echèk nan
+      konfòme yo ak nenpòt garanti yo pral sèl responsablite nan psi.
+    </li>
+  </ol>
+  <ol>
+
+    <li>Ou ak PCI rekonèt ke, ant PCI ak Apple, Apple pa responsab pou adrese nenpòt reklamasyon ou
+      gen oswa nenpòt reklamasyon nan nenpòt ki twazyèm pati ki gen rapò ak App Store Sourcing
+      Aplikasyon an oswa posesyon ou epi sèvi ak nan App Store Sourcing Aplikasyon an, ki gen ladan,
+      men se pa sa sèlman: (i) reklamasyon responsablite pwodwi; (ii) nenpòt ki reklamasyon ke App
+      Store Sourcing Aplikasyon an echwe konfòme yo ak nenpòt ki aplikab egzijans legal oswa
+      regilasyon; ak (iii) reklamasyon ki rive anba pwoteksyon konsomatè oswa lejislasyon ki
+      sanble.<br>
+
+
+    <li>Ou ak PCI rekonèt ke, nan evènman an nan nenpòt ki reklamasyon twazyèm-pati ki App Store
+      Sourcing Aplikasyon an oswa posesyon ou ak itilizasyon sa yo ki Aplikasyon App Store Sourced
+      vyole dwa pwopriyete entelektyèl twazyèm pati a, kòm ant psi ak Apple, psi, pa Apple. , pral
+      sèl
+      responsab pou ankèt la, defans, règleman ak egzeyat nan nenpòt ki reklamasyon enfraksyon
+      pwopriyete sa yo nan limit ki nan Kontra sa-a egzije.
+    </li>
+  </ol>
+  <ol>
+
+    <li>Ou menm ak PCI rekonèt epi mwen dakò ke Apple, ak filiales Apple la, se yo se benefisyè
+      twazyèm pati nan Kontra sa-a kòm ki gen rapò ak lisans ou nan App Store Sourcing Aplikasyon
+      an,
+      e ke, sou akseptasyon ou nan tèm ak kondisyon nan Kontra sa-a, Apple ap gen dwa a (epi yo pral
+      jije yo te aksepte dwa a ... ) ranfòse Kontra sa a kòm ki gen rapò ak lisans ou nan App
+      Aplikasyon an Sourced magazen kont ou kòm yon benefisyè twazyèm-pati ladan l '.
+
+    <li>San yo pa limite nenpòt lòt tèm nan Kontra sa-a, ou dwe konfòme yo avèk tout aplikab tèm
+      twazyèm-pati nan akò lè w ap itilize App Store Sourcing Aplikasyon an.
+    </li>
+  </ol>
+  <p>
+    <strong>6.14 Plent Konsomatè.</strong> An akò avèk Kòd Sivil Kalifòni §1789.3, ou ka rapòte
+    plent
+    bay Inite a Asistans Plent nan Divizyon Sèvis pou Konsomatè nan Depatman Kalifòni nan Zafè
+    Konsomatè nan Kalifòni lè w kontakte yo alekri nan 1625 North Market Blvd., Suite N 112,
+    Sacramento, CA 95834, oswa pa telefòn nan (800) 952-5210.
+  </p>
+  <p>
+    <strong>6.15 Tout Akò.</strong> Akò sa a se akò final, konplè ak eksklizif de pati yo ki gen
+    rapò
+    ak matyè a nan sa a ak ranplase ak melanje tout diskisyon anvan ant pati yo ki gen rapò ak matyè
+    sa yo.
+  </p>
+  <p>
+
+  </p>
+</body>
+
+</html>
+
+`;


### PR DESCRIPTION
**note:** Will rebase onto master when #638 merges

Adds webview with EULA for English and Haitian Creole

#### Linked issues:

See #638 

#### Screenshots:

<img width="454" alt="Screen Shot 2020-04-23 at 10 40 54 PM" src="https://user-images.githubusercontent.com/702990/80178614-7f52e280-85b3-11ea-9d93-d3e461400d63.png">

<img width="454" alt="Screen Shot 2020-04-23 at 10 45 16 PM" src="https://user-images.githubusercontent.com/702990/80178927-38b1b800-85b4-11ea-8060-1604ec3a3d85.png">


#### How to test

- Verify that english and ht have different EULAs, and that any other lanuage uses english
- EULA formatting is a little off
