### PR TITLE
Add in a 6 hour time period between notifications

### DIFF
--- a/app/constants/history.js
+++ b/app/constants/history.js
@@ -15,6 +15,17 @@ export const DEFAULT_EXPOSURE_PERIOD_MINUTES = 5;
 export const CONCERN_TIME_WINDOW_MINUTES = 4 * 60; // 4 hours, in minutes
 
 /**
+ * The value in minutes of how frequently we should check intersection data if
+ *    there has been no change to the authorities
+ */
+export const MIN_CHECK_INTERSECT_INTERVAL = 6 * 60;
+
+/**
+ * The value in minutes for the background task service to register for firing
+ */
+export const INTERSECT_INTERVAL = 60 * 12; // 12 Hours, the value is received in minutes
+
+/**
  * Format of a single history item
  *
  * @typedef {{

--- a/app/helpers/Intersect.js
+++ b/app/helpers/Intersect.js
@@ -13,6 +13,7 @@ import {
   CONCERN_TIME_WINDOW_MINUTES,
   DEFAULT_EXPOSURE_PERIOD_MINUTES,
   MAX_EXPOSURE_WINDOW_DAYS,
+  MIN_CHECK_INTERSECT_INTERVAL,
 } from '../constants/history';
 import {
   AUTHORITY_NEWS,
@@ -270,6 +271,11 @@ export function checkIntersect() {
  * Returns the array of day bins (mostly for debugging purposes)
  */
 async function asyncCheckIntersect() {
+
+  // first things first ... is it time to actually try the intersection?
+  let last_checked_ms = await GetStoreData(LAST_CHECKED);
+  if (last_checked_ms + MIN_CHECK_INTERSECT_INTERVAL * 60 * 1000 > dayjs().valueOf()) return null;
+
   // Set up the empty set of dayBins for intersections, and the array for the news urls
   let dayBins = getEmptyLocationBins();
   let name_news = [];

--- a/app/helpers/Intersect.js
+++ b/app/helpers/Intersect.js
@@ -260,7 +260,11 @@ export function checkIntersect() {
   );
 
   asyncCheckIntersect().then(result => {
-    console.log('[intersect] completed: ', result);
+    if (result === null) {
+      console.log('[intersect] skipped');
+    } else {
+      console.log('[intersect] completed: ', result);
+    }
   });
 }
 
@@ -273,7 +277,7 @@ export function checkIntersect() {
 async function asyncCheckIntersect() {
 
   // first things first ... is it time to actually try the intersection?
-  let last_checked_ms = await GetStoreData(LAST_CHECKED);
+  let last_checked_ms =Number(await GetStoreData(LAST_CHECKED));
   if (last_checked_ms + MIN_CHECK_INTERSECT_INTERVAL * 60 * 1000 > dayjs().valueOf()) return null;
 
   // Set up the empty set of dayBins for intersections, and the array for the news urls

--- a/app/services/BackgroundTaskService.js
+++ b/app/services/BackgroundTaskService.js
@@ -37,6 +37,5 @@ export default class BackgroundTaskServices {
 
   static stop() {
     BackgroundFetch.stop();
-    BSCount--;
   }
 }

--- a/app/services/BackgroundTaskService.js
+++ b/app/services/BackgroundTaskService.js
@@ -1,8 +1,7 @@
 import BackgroundFetch from 'react-native-background-fetch';
 
+import { INTERSECT_INTERVAL } from '../constants/history';
 import { checkIntersect } from '../helpers/Intersect';
-
-const INTERSECT_INTERVAL = 60 * 12; // 12 Hours, the value is received in minutes
 
 export function executeTask() {
   checkIntersect();
@@ -38,5 +37,6 @@ export default class BackgroundTaskServices {
 
   static stop() {
     BackgroundFetch.stop();
+    BSCount--;
   }
 }

--- a/app/views/ChooseProvider.js
+++ b/app/views/ChooseProvider.js
@@ -6,7 +6,6 @@ import {
   Dimensions,
   FlatList,
   Image,
-  SafeAreaView,
   StyleSheet,
   TouchableOpacity,
   View,
@@ -81,8 +80,8 @@ class ChooseProviderScreen extends Component {
 
   componentWillUnmount() {
     BackHandler.removeEventListener('hardwareBackPress', this.handleBackPress);
-    // save off the current time as the last checked time
-  SetStoreData(LAST_CHECKED, 0);
+    // set the LAST_CHECKED time to 0, so the intersection will kick off
+    SetStoreData(LAST_CHECKED, 0);
   }
 
   fetchAuthoritiesList() {

--- a/app/views/ChooseProvider.js
+++ b/app/views/ChooseProvider.js
@@ -31,7 +31,7 @@ import { AUTHORITIES_LIST_URL } from '../constants/authorities';
 import colors from '../constants/colors';
 import Colors from '../constants/colors';
 import fontFamily from '../constants/fonts';
-import { AUTHORITY_SOURCE_SETTINGS } from '../constants/storage';
+import { AUTHORITY_SOURCE_SETTINGS, LAST_CHECKED } from '../constants/storage';
 import { GetStoreData, SetStoreData } from '../helpers/General';
 import { checkIntersect } from '../helpers/Intersect';
 import languages from '../locales/languages';
@@ -81,6 +81,8 @@ class ChooseProviderScreen extends Component {
 
   componentWillUnmount() {
     BackHandler.removeEventListener('hardwareBackPress', this.handleBackPress);
+    // save off the current time as the last checked time
+  SetStoreData(LAST_CHECKED, 0);
   }
 
   fetchAuthoritiesList() {


### PR DESCRIPTION
Adds in a 6 hour interval between actually running the intersection (and therefore notifying the user of being at risk).  What this means is that we will really only check for intersections every 6 hours.  This has an added benefit that we will only download from the health authority every 6 hours as well.

If the user navigates to the ChooseProvider screen, the timer as they back out, so the intersection will again run one time afterwards.
