### PR TITLE
Polish the EULA

### DIFF
--- a/app/components/EulaModal.js
+++ b/app/components/EulaModal.js
@@ -39,7 +39,7 @@ const webViewScrollDetection = `
   };
 
   function scrollHandler() {
-    if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {
+    if (window.innerHeight + window.scrollY >= document.body.offsetHeight - 30) {
       window.ReactNativeWebView.postMessage('end');
     } else {
       window.ReactNativeWebView.postMessage('scroll');
@@ -76,7 +76,7 @@ export const EulaModal = ({ selectedLocale, continueFunction }) => {
   // Pull the EULA in the correct language, with en as fallback
   const html = EULA_FILES[selectedLocale] || en_html;
 
-  const canContinue = boxChecked && hasScrolledToEnd;
+  const canContinue = boxChecked; // && hasScrolledToEnd;
 
   return (
     <>
@@ -89,7 +89,7 @@ export const EulaModal = ({ selectedLocale, continueFunction }) => {
       <Modal animationType='slide' transparent visible={modalVisible}>
         <View style={styles.container}>
           <SafeAreaView style={{ flex: 1 }}>
-            <View style={{ flex: 7, paddingHorizontal: 25, paddingBottom: 0 }}>
+            <View style={{ flex: 7, paddingHorizontal: 5, paddingBottom: 0 }}>
               <TouchableOpacity onPress={() => setModalVisibility(false)}>
                 <Image source={closeIcon} style={styles.closeIcon} />
               </TouchableOpacity>
@@ -143,7 +143,7 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.WHITE,
   },
   ctaBox: {
-    padding: 25,
+    padding: 15,
     paddingTop: 0,
     backgroundColor: Colors.VIOLET_BUTTON,
   },

--- a/app/locales/eula/en_html.js
+++ b/app/locales/eula/en_html.js
@@ -5,6 +5,17 @@ export default `
 <head>
   <meta name="viewport"
         content="width=device-width, initial-scale=1.0">
+
+  <style>
+      html {
+        font-size: 12px;
+      }
+
+      ol, ul {
+        padding-left: 5px;
+        margin-left: 5px;
+      }
+  </style>
 </head>
 
 <body>

--- a/app/locales/eula/ht_html.js
+++ b/app/locales/eula/ht_html.js
@@ -7,18 +7,14 @@ export default `
         content="width=device-width, initial-scale=1.0">
 
   <style>
-    ol {
-      counter-reset: item
-    }
+      html {
+        font-size: 12px;
+      }
 
-    li {
-      display: block
-    }
-
-    li:before {
-      content: counters(item, ".") " ";
-      counter-increment: item
-    }
+      ol, ul {
+        padding-left: 5px;
+        margin-left: 5px;
+      }
   </style>
 </head>
 


### PR DESCRIPTION
Several changes to make the EULA palatable:
* Reduced the indents in the HTML with inline CSS
* Reduced text size so it is small like legal text should be ;-)
* Reducing some padding around elements to fit small Android 6 screen
* Removed the scroll to botton -- injected javascript was not running,
  or at least not generating any calls to handleWebViewMessage()

 ### Testing Notes ###
Install, look at the glorious EULA!

 ### Tech Notes ###
Under the Android 6 emulator I never got any messages when I placed
a console.log("here!") in the handleWebViewMessage().  I'm assuming
the webview didn't support injecting JS back then.