### PR TITLE
BUGFIX: Add authority wasn't immediate

### DIFF
--- a/app/views/ChooseProvider.js
+++ b/app/views/ChooseProvider.js
@@ -82,6 +82,9 @@ class ChooseProviderScreen extends Component {
     BackHandler.removeEventListener('hardwareBackPress', this.handleBackPress);
     // set the LAST_CHECKED time to 0, so the intersection will kick off
     SetStoreData(LAST_CHECKED, 0);
+
+    // Force update, this will download any changed Healthcare Authorities
+    checkIntersect();
   }
 
   fetchAuthoritiesList() {
@@ -139,10 +142,7 @@ class ChooseProviderScreen extends Component {
           SetStoreData(
             AUTHORITY_SOURCE_SETTINGS,
             this.state.selectedAuthorities,
-          ).then(() => {
-            // Force updates immediately.
-            checkIntersect();
-          });
+          );
         },
       );
     } else {
@@ -172,10 +172,7 @@ class ChooseProviderScreen extends Component {
           SetStoreData(
             AUTHORITY_SOURCE_SETTINGS,
             this.state.selectedAuthorities,
-          ).then(() => {
-            // Force updates immediately.
-            checkIntersect();
-          });
+          );
         },
       );
     }
@@ -208,10 +205,7 @@ class ChooseProviderScreen extends Component {
                 SetStoreData(
                   AUTHORITY_SOURCE_SETTINGS,
                   this.state.selectedAuthorities,
-                ).then(() => {
-                  // Force updates immediately.
-                  checkIntersect();
-                });
+                );
               },
             );
           },


### PR DESCRIPTION
The 6-hour limit on recalculation of the intersection introduced
and unintended problem with the Choose Health Authority page.  It
would not complete an Intersection process, so no new authority's
URL would get pulled down until hours later.

Now it happens immediately upon leaving the Choose page, like before.

 ### Testing Notes ###
* Go to News.  See only Safe Paths (default)
* Go to Add Healthcare Authorityies.  Add one
* Wait a couple seconds and go back to News.  New authority's news
  should appear now.