### PR TITLE
Hide unintented "What does this mean?" message

### DIFF
--- a/app/views/ExposureHistory/DetailedHistory.js
+++ b/app/views/ExposureHistory/DetailedHistory.js
@@ -37,14 +37,17 @@ export const DetailedHistory = ({ history }) => {
           </Typography>
           <Divider />
         </>
-      ) : null}
+      ) : (
+        <>
+          <Typography use='headline3'>
+            {languages.t('history.what_does_this_mean')}
+          </Typography>
+          <Typography use='body3'>
+            {languages.t('history.what_does_this_mean_para')}
+          </Typography>
+        </>
+      )}
 
-      <Typography use='headline3'>
-        {languages.t('history.what_does_this_mean')}
-      </Typography>
-      <Typography use='body3'>
-        {languages.t('history.what_does_this_mean_para')}
-      </Typography>
       <Divider />
 
       {exposedDays.length ? (


### PR DESCRIPTION
The "What does this mean?" message was appearing on the Exposure
History page even when you didn't have exposure.

 ### Testing Notes ###
Go to Exposure History.  Message shouldn't be there.

Go to About, 4x click on people to go into debug

Go to Exposure History.  Message should appear