### PR TITLE
Fit_text_InsideView

### DIFF
--- a/app/components/NavigationBarWrapper.js
+++ b/app/components/NavigationBarWrapper.js
@@ -69,6 +69,7 @@ const Header = styled.View`
   border-bottom-color: ${themeNavBarBorder};
   border-bottom-width: 1px;
   flex-direction: row;
+  padding-vertical: 10;
 `;
 
 const Title = styled.Text`


### PR DESCRIPTION
Resolves issue #618 ,
Fit Title text of all languages inside Header View . 
![Screenshot_title_InsideView_COVID Safe Paths](https://user-images.githubusercontent.com/62654508/80204954-6f84de00-8647-11ea-8ed6-194f3ceb3384.jpg)
 