### PR TITLE
Fix some numbering and formatting problems on en and ht EULAs

### DIFF
--- a/app/locales/eula/en_html.js
+++ b/app/locales/eula/en_html.js
@@ -21,13 +21,13 @@ export default `
 <body>
     <p><strong>Terms of Use</strong></p>
     <p><strong>Last Updated Date: April 23, 2020</strong></p>
-    <p>PLEASE READ THIS TERMS OF USE AGREEMENT (THE &ldquo;TERMS
-            OF USE&rdquo; </strong>OR &ldquo;AGREEMENT&rdquo;
-                    ) CAREFULLY. &nbsp;THE SAFE PATH MOBILE APPLICATION (THE &ldquo;APPLICATION&rdquo;
+    <p>PLEASE READ THIS TERMS OF USE AGREEMENT (THE “TERMS
+            OF USE” </strong>OR “AGREEMENT”
+                    ) CAREFULLY. &nbsp;THE SAFE PATH MOBILE APPLICATION (THE “APPLICATION”
             </strong>), AND THE FEATURES AND INFORMATION IN IT ARE
-            CONTROLLED BY PATH CHECK, INC. (&ldquo;PCI</strong>&rdquo;).
+            CONTROLLED BY PATH CHECK, INC. (“PCI</strong>”).
             &nbsp;THESE TERMS OF USE GOVERN THE USE OF THE APPLICATION AND APPLY TO ALL USERS USING THE APPLICATION IN
-            ANY WAY, INCLUDING THE FEATURES THEREIN. BY CLICKING ON THE &ldquo;I ACCEPT&rdquo; BUTTON AND/OR DOWNLOADING
+            ANY WAY, INCLUDING THE FEATURES THEREIN. BY CLICKING ON THE “I ACCEPT” BUTTON AND/OR DOWNLOADING
             THE APPLICATION, YOU REPRESENT THAT (1) YOU HAVE READ, UNDERSTAND, AND AGREE TO BE BOUND BY THE TERMS OF
             USE, (2) YOU ARE OF LEGAL AGE TO FORM A BINDING CONTRACT WITH PCI, AND (3) YOU HAVE THE AUTHORITY TO ENTER
             INTO THE TERMS OF USE. &nbsp;IF YOU DO NOT AGREE TO BE BOUND BY THE TERMS OF USE,
@@ -48,31 +48,31 @@ export default `
             INTERNATIONAL SALE OF GOODS IS EXPRESSLY EXCLUDED FROM THIS AGREEMENT. </strong></p>
     <p>PLEASE NOTE THAT <strong>THIS AGREEMENT IS SUBJECT TO CHANGE BY PCI
             IN ITS SOLE DISCRETION AT ANY TIME</strong>. &nbsp;When changes are made, PCI will make a new
-            copy of the Terms of Use available within the Application. &nbsp;We will also update the &ldquo;Last
-            Updated&rdquo; date at the top of the Terms of Use. &nbsp;Your continued use of the Application after a
+            copy of the Terms of Use available within the Application. &nbsp;We will also update the “Last
+            Updated” date at the top of the Terms of Use. &nbsp;Your continued use of the Application after a
             change to the Terms of Use is made constitutes acceptance. &nbsp;PLEASE REGULARLY CHECK THE APPLICATION TO
             VIEW THE MOST CURRENT TERMS.</p>
     <p><strong>1. USE OF THE APPLICATION.</strong>&nbsp;
         </strong></p>
     <p><strong>1.1 Definitions</strong>. &nbsp;As used in
             these Terms of Use, the following definitions apply:</p>
-    <p><strong>&ldquo;App User</strong>&rdquo; means an
+    <p><strong>“App User</strong>” means an
             individual natural person who has downloaded the Application under these Terms of Use.</p>
-    <p><strong>&ldquo;Location History</strong>&rdquo;
+    <p><strong>“Location History</strong>”
             means location data collected from an App User&rsquo;s mobile device leveraging GPS, Bluetooth and/or other
             features or software, that the App User elects to have recorded and stored within the Application installed
             on the App User&rsquo;s mobile device.</p>
-    <p><strong>&ldquo;Publicly Available Safe Places Data</strong>
-            &rdquo; means anonymized maps of public places where individuals diagnosed with Covid-19 have
+    <p><strong>“Publicly Available Safe Places Data</strong>
+            ” means anonymized maps of public places where individuals diagnosed with Covid-19 have
             visited and data files of times they visited such places, as compiled and created by a third party, and made
             available via such third party&rsquo;s Third Party Safe Places Web App.</p>
-    <p><strong>&ldquo;Safe Places Software</strong>&rdquo;
+    <p><strong>“Safe Places Software</strong>”
             means open-source software, available at </strong><span class="c8"><a class="c11"
                 href="https://www.google.com/url?q=https://github.com/tripleblindmarket/safe-places&amp;sa=D&amp;ust=1587722145899000">https://github.com/tripleblindmarket/safe-places</a></strong>
                         , that facilitates contact tracing and related tasks, and is designed for use by third parties,
             such as government agencies. </span></p>
-    <p><strong>&ldquo;Third Party Safe Places Web App</strong>
-            &rdquo; means a web-based application owned and operated by a third party, such as a government
+    <p><strong>“Third Party Safe Places Web App</strong>
+            ” means a web-based application owned and operated by a third party, such as a government
             agency, that employs Safe Places Software to, among other things, publish Publicly Available Safe Places
             Data.</p>
     <p><strong>1.2 Application Features and Functionality.</strong>
@@ -95,20 +95,20 @@ export default `
         </strong><span class="c8"><a class="c11"
                 href="https://www.google.com/url?q=https://github.com/tripleblindmarket/covid-safe-paths/blob/develop/LICENSE&amp;sa=D&amp;ust=1587722145900000">https://github.com/tripleblindmarket/covid-safe-paths/blob/develop/LICENSE</a></strong>
                         . &nbsp;Furthermore, with respect to any Application accessed through or downloaded from the
-            Apple App Store (an&nbsp;&ldquo;App Store Sourced Application&rdquo;</strong>
+            Apple App Store (an&nbsp;“App Store Sourced Application”</strong>
                       ), you will only use the App Store Sourced Application (a) on an Apple-branded product that runs
-            the iOS (Apple&rsquo;s proprietary operating system) and (b) as permitted by the &ldquo;Usage Rules&rdquo;
+            the iOS (Apple&rsquo;s proprietary operating system) and (b) as permitted by the “Usage Rules”
             set forth in the Apple App Store Terms of Service. Notwithstanding the first sentence in this section, with
-            respect to any Application accessed through or downloaded from the Google Play store (a &ldquo;
-            Google Play Sourced Application</strong>&rdquo;), you may have additional
+            respect to any Application accessed through or downloaded from the Google Play store (a “
+            Google Play Sourced Application</strong>”), you may have additional
             license rights with respect to use of the Application on a shared basis within your designated family
             group.</p>
     <p id="h.gjdgxs"><strong>1.4 Updates.</strong>&nbsp;
             You understand that to keep the Application most useful for App Users and to accommodate bug fixes and other
             technological changes, PCI may make updates to the Application after you download the Application.
             &nbsp;These updates will be made available to App Users from the third party from whom you received the
-            Application license, e.g., the Apple App Store or Google Play (each, an &ldquo;App Store
-            &rdquo;</strong>). &nbsp;You will have the ability, at your
+            Application license, e.g., the Apple App Store or Google Play (each, an “App Store
+            ”</strong>). &nbsp;You will have the ability, at your
             option, to download any updates to the Application that we make freely available through such channels.
             &nbsp;We do not require you to install any updates in order for you to continue using the Application after
             we make such updates available. &nbsp;This is because we do not retain any information about you when you
@@ -159,7 +159,7 @@ export default `
             consequences that may result because you have released or shared information, through the Application or
             otherwise, with a third party. &nbsp;</p>
     <p><strong>4. FEEDBACK</strong>. &nbsp;If you provide
-            PCI with any ideas, suggestions, documents, and/or proposals (&ldquo;Feedback&rdquo;
+            PCI with any ideas, suggestions, documents, and/or proposals (“Feedback”
             </strong>) via email or another means, you do so at your
             own risk and you acknowledge and agree that PCI has no obligations (including without limitation obligations
             of confidentiality) with respect to such Feedback. &nbsp;You represent and warrant that you have all rights
@@ -189,8 +189,8 @@ export default `
             forth herein.</p>
     <p><strong>7. INDEMNIFICATION. &nbsp;</strong>You
             agree to indemnify and hold PCI, its parents, subsidiaries, affiliates, officers, employees, volunteers,
-            agents, partners, suppliers, and licensors (each, a &ldquo;PCI Party
-                      &rdquo; and collectively, the &ldquo;PCI Parties&rdquo;
+            agents, partners, suppliers, and licensors (each, a “PCI Party
+                      ” and collectively, the “PCI Parties”
                       ) harmless from any losses, costs, liabilities and expenses (including reasonable
             attorneys&rsquo; fees) relating to or arising out of any and all of the following: (a) your use of, or
             inability to use the Application; (b) your violation of this Agreement; (c) your violation of any rights of
@@ -205,7 +205,7 @@ export default `
     <p><strong>8. DISCLAIMER OF WARRANTIES AND CONDITIONS.</strong></p>
     <p><strong>8.1 As Is.</strong>&nbsp;YOU EXPRESSLY
             UNDERSTAND AND AGREE THAT TO THE EXTENT PERMITTED BY APPLICABLE LAW, YOUR USE OF THE APPLICATION IS AT YOUR
-            SOLE RISK, AND THE APPLICATION IS PROVIDED ON AN &ldquo;AS IS&rdquo; AND &ldquo;AS AVAILABLE&rdquo; BASIS,
+            SOLE RISK, AND THE APPLICATION IS PROVIDED ON AN “AS IS” AND “AS AVAILABLE” BASIS,
             WITH ALL FAULTS. &nbsp;THE PCI PARTIES EXPRESSLY DISCLAIM ALL WARRANTIES, REPRESENTATIONS, AND CONDITIONS OF
             ANY KIND, WHETHER EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OR CONDITIONS OF
             MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARISING FROM USE OF THE APPLICATION.
@@ -224,7 +224,7 @@ export default `
             EFFECTIVENESS, REPUTATION AND OTHER CHARACTERISTICS THEREOF.</p>
     <p><strong>(d) </strong>NO ADVICE OR INFORMATION, WHETHER ORAL OR WRITTEN,
             OBTAINED FROM PCI OR THROUGH THE APPLICATION WILL CREATE ANY WARRANTY NOT EXPRESSLY MADE HEREIN.</p>
-    <p><strong>(e) </strong>FROM TIME TO TIME, PCI MAY OFFER NEW &ldquo;BETA&rdquo;
+    <p><strong>(e) </strong>FROM TIME TO TIME, PCI MAY OFFER NEW “BETA”
             FEATURES OR TOOLS WITH WHICH ITS USERS MAY EXPERIMENT. &nbsp;SUCH FEATURES OR TOOLS ARE OFFERED SOLELY FOR
             EXPERIMENTAL PURPOSES AND WITHOUT ANY WARRANTY OF ANY KIND, AND MAY BE MODIFIED OR DISCONTINUED AT
             PCI&rsquo;S SOLE DISCRETION. &nbsp;THE PROVISIONS OF THIS SECTION APPLY WITH FULL FORCE TO SUCH FEATURES OR
@@ -316,8 +316,8 @@ export default `
             other countries do so at their own risk and are responsible for use in compliance with local law.</strong></p>
     <p id="h.30j0zll"><strong>13. DISPUTE RESOLUTION.</strong>
             &nbsp; <strong>Please read the following
-            arbitration agreement in this Section (&ldquo;Arbitration Agreement
-            &rdquo;) carefully.&nbsp; It requires U.S. users to arbitrate disputes with PCI and limits the
+            arbitration agreement in this Section (“Arbitration Agreement
+            ”) carefully.&nbsp; It requires U.S. users to arbitrate disputes with PCI and limits the
             manner in which you can seek relief from us. &nbsp;</strong></p>
     <p id="h.1fob9te"><strong>13.1 Applicability of Arbitration
             Agreement</strong>.&nbsp;You agree that any dispute, claim, or
@@ -412,17 +412,17 @@ export default `
             electronically satisfy any legal requirement that such communications would satisfy if it were to be in
             writing. &nbsp;The foregoing does not affect your statutory rights, including but not limited to the
             Electronic Signatures in Global and National Commerce Act at 15 U.S.C. &sect;7001 et seq.
-            (&ldquo;E-Sign&rdquo;).</p>
+            (“E-Sign”).</p>
     <p><strong>14.2 Release.</strong>&nbsp; You hereby
             release the PCI Parties and their successors from claims, demands, any and all losses, damages, rights, and
             actions of any kind, including personal injuries, death, and property damage, that is either directly or
             indirectly related to or arises from any interactions with or conduct of operators of Third Party Safe
             Places Web Apps, healthcare providers, governmental agencies, of any kind arising in connection with or as a
             result of this Agreement or your use of the Application. &nbsp;If you are a California resident, you hereby
-            waive California Civil Code Section 1542, which states, &ldquo;A general release does not extend to claims
+            waive California Civil Code Section 1542, which states, “A general release does not extend to claims
             that the creditor or releasing party does not know or suspect to exist in his or her favor at the time of
             executing the release and that, if known by him or her, would have materially affected his or her settlement
-            with the debtor or released party.&rdquo; &nbsp;The foregoing release does not apply to any claims, demands,
+            with the debtor or released party.” &nbsp;The foregoing release does not apply to any claims, demands,
             or any losses, damages, rights and actions of any kind, including personal injuries, death or property
             damage for any unconscionable commercial practice by a PCI Party or for such party&rsquo;s fraud, deception,
             false, promise, misrepresentation or concealment, suppression or omission of any material fact in connection
@@ -470,8 +470,8 @@ export default `
             countries, or (b) to anyone on the U.S. Treasury Department&rsquo;s list of Specially Designated Nationals
             or the U.S. Department of Commerce&rsquo;s Denied Person&rsquo;s List or Entity List. By using the
             Application, you represent and warrant that (y) you are not located in a country that is subject to a U.S.
-            Government embargo, or that has been designated by the U.S. Government as a &ldquo;terrorist
-            supporting&rdquo; country and (z) you are not listed on any U.S. Government list of prohibited or restricted
+            Government embargo, or that has been designated by the U.S. Government as a “terrorist
+            supporting” country and (z) you are not listed on any U.S. Government list of prohibited or restricted
             parties. You also will not use the Application for any purpose prohibited by U.S. law, including the
             development, design, manufacture or production of missiles, nuclear, chemical or biological weapons.
             &nbsp;You acknowledge and agree that products, services or technology provided by PCI are subject to the

--- a/app/locales/eula/en_html.js
+++ b/app/locales/eula/en_html.js
@@ -19,682 +19,515 @@ export default `
 </head>
 
 <body>
-  <p>
-    <strong>Terms of Use</strong>
-  </p>
-  <p>
-    <strong>Last Updated Date: April 23, 2020</strong>
-  </p>
-  <p>
-    PLEASE READ THIS TERMS OF USE AGREEMENT (THE <strong>“TERMS OF USE” </strong>OR
-    <strong>“AGREEMENT”</strong>) CAREFULLY. THE SAFE PATH MOBILE APPLICATION (THE
-    “<strong>APPLICATION”</strong>), AND THE FEATURES AND INFORMATION IN IT ARE CONTROLLED BY PATH
-    CHECK, INC. (“<strong>PCI</strong>”). THESE TERMS OF USE GOVERN THE USE OF THE APPLICATION AND
-    APPLY TO ALL USERS USING THE APPLICATION IN ANY WAY, INCLUDING THE FEATURES THEREIN. BY CLICKING
-    ON THE “I ACCEPT” BUTTON AND/OR DOWNLOADING THE APPLICATION, YOU REPRESENT THAT (1) YOU HAVE
-    READ, UNDERSTAND, AND AGREE TO BE BOUND BY THE TERMS OF USE, (2) YOU ARE OF LEGAL AGE TO FORM A
-    BINDING CONTRACT WITH PCI, AND (3) YOU HAVE THE AUTHORITY TO ENTER INTO THE TERMS OF USE.
-    <strong>IF YOU DO NOT AGREE TO BE BOUND BY THE TERMS OF USE, YOU MAY NOT ACCESS OR USE THE
-      APPLICATION</strong>.
-  </p>
-  <p>
-    <strong>PLEASE BE AWARE THAT SECTION 13 OF THIS AGREEMENT, BELOW, CONTAINS PROVISIONS GOVERNING
-      HOW DISPUTES THAT YOU AND WE HAVE AGAINST EACH OTHER ARE RESOLVED, INCLUDING, WITHOUT
-      LIMITATION, ANY DISPUTES THAT AROSE OR WERE ASSERTED PRIOR TO THE EFFECTIVE DATE OF THIS
-      AGREEMENT. IN PARTICULAR, IT CONTAINS AN ARBITRATION AGREEMENT WHICH WILL, WITH LIMITED
-      EXCEPTIONS, REQUIRE DISPUTES BETWEEN US TO BE SUBMITTED TO BINDING AND FINAL ARBITRATION.
-      UNLESS YOU OPT OUT OF THE ARBITRATION AGREEMENT: (1) YOU WILL ONLY BE PERMITTED TO PURSUE
-      DISPUTES OR CLAIMS AND SEEK RELIEF AGAINST US ON AN INDIVIDUAL BASIS, NOT AS A PLAINTIFF OR
-      CLASS MEMBER IN ANY CLASS OR REPRESENTATIVE ACTION OR PROCEEDING; AND (2) YOU ARE WAIVING YOUR
-      RIGHT TO PURSUE DISPUTES OR CLAIMS AND SEEK RELIEF IN A COURT OF LAW AND TO HAVE A JURY TRIAL.
-    </strong>
-  </p>
-  <p>
-    <strong>ANY DISPUTE, CLAIM OR REQUEST FOR RELIEF RELATING IN ANY WAY TO YOUR USE OF THE
-      APPLICATION WILL BE GOVERNED AND INTERPRETED BY AND UNDER THE LAWS OF THE COMMONWEALTH OF
-      MASSACHUSETTS, CONSISTENT WITH THE FEDERAL ARBITRATION ACT, WITHOUT GIVING EFFECT TO ANY
-      PRINCIPLES THAT PROVIDE FOR THE APPLICATION OF THE LAW OF ANY OTHER JURISDICTION. THE UNITED
-      NATIONS CONVENTION ON CONTRACTS FOR THE INTERNATIONAL SALE OF GOODS IS EXPRESSLY EXCLUDED FROM
-      THIS AGREEMENT. </strong>
-  </p>
-  <p>
-    PLEASE NOTE THAT THIS AGREEMENT IS SUBJECT TO CHANGE BY PCI IN ITS SOLE DISCRETION AT ANY TIME.
-    When changes are made, PCI will make a new copy of the Terms of Use available within the
-    Application. We will also update the “Last Updated” date at the top of the Terms of Use. Your
-    continued use of the Application after a change to the Terms of Use is made constitutes
-    acceptance. PLEASE REGULARLY CHECK THE APPLICATION TO VIEW THE MOST CURRENT TERMS.
-  </p>
-  <ol>
-
-    <li>
-      <strong>USE OF THE APPLICATION.</strong>
-      <ol>
-
-        <li>
-          <strong>Definitions</strong>. As used in these Terms of Use, the following definitions
-          apply:
-          <p>
-            “<strong>App User</strong>” means an individual natural person who has downloaded the
-            Application under these Terms of Use.
-          </p>
-          <p>
-            “<strong>Location History</strong>” means location data collected from an App User’s
-            mobile device leveraging GPS, Bluetooth and/or other features or software, that the App
-            User elects to have recorded and stored within the Application installed on the App
-            User’s mobile device.
-          </p>
-          <p>
-            “<strong>Publicly Available Safe Places Data</strong>” means anonymized maps of public
-            places where individuals diagnosed with Covid-19 have visited and data files of times
-            they visited such places, as compiled and created by a third party, and made available
-            via such third party’s Third Party Safe Places Web App.
-          </p>
-          <p>
-            “<strong>Safe Places Software</strong>” means open-source software, available at <a
-               href="https://github.com/tripleblindmarket/safe-places">https://github.com/tripleblindmarket/safe-places</a>,
-            that facilitates contact tracing and related tasks, and is designed for use by third
-            parties, such as government agencies.
-          </p>
-          <p>
-            “<strong>Third Party Safe Places Web App</strong>” means a web-based application owned
-            and operated by a third party, such as a government agency, that employs Safe Places
-            Software to, among other things, publish Publicly Available Safe Places Data.
-          </p>
-          <ol>
-
-            <li>
-              <strong>Application Features and Functionality.</strong> The Application is designed
-              to enable App Users, <span style="text-decoration:underline;">at their option</span>:
-              (a) to record their Location History and to store such data locally in the Application
-              downloaded to their mobile device, (b) to access Publicly Available Safe Places Data
-              from one or more Third Party Safe Places Web Apps and download it to the Safe Paths
-              App downloaded on their mobile device, and (c) to share their stored Location History
-              with third parties that they choose.
-
-            <li><strong>Application License. </strong>The Application and the information and
-              content available therein are protected by copyright laws throughout the world.
-              Subject to your compliance with this Agreement, PCI grants you a limited
-              non-exclusive, non-transferable, non-sublicensable, revocable license to download,
-              install and use a copy of the Application on a single mobile device or computer that
-              you own or control and to run such copy of the Application solely for your own
-              personal or internal business purposes. Certain components or libraries included in or
-              bundled with the Application constitute open source software and are licensed under
-              open source licenses. To the extent required by such open source licenses, the terms
-              of such licenses will apply in lieu of the terms of this Section 1.3, solely with
-              respect to those components or libraries that are licensed under such open source
-              licenses. For a copy of such open source licenses, visit <a
-                 href="https://github.com/tripleblindmarket/covid-safe-paths/blob/develop/LICENSE">https://github.com/tripleblindmarket/covid-safe-paths/blob/develop/LICENSE</a>.
-              Furthermore, with respect to any Application accessed through or downloaded from the
-              Apple App Store (an<strong> “App Store Sourced Application”</strong>), you will only
-              use the App Store Sourced Application (a) on an Apple-branded product that runs the
-              iOS (Apple’s proprietary operating system) and (b) as permitted by the “Usage Rules”
-              set forth in the Apple App Store Terms of Service. Notwithstanding the first sentence
-              in this section, with respect to any Application accessed through or downloaded from
-              the Google Play store (a “<strong>Google Play Sourced Application</strong>”), you may
-              have additional license rights with respect to use of the Application on a shared
-              basis within your designated family group.
-
-            <li><strong>Updates.</strong> You understand that to keep the Application most useful
-              for App Users and to accommodate bug fixes and other technological changes, PCI may
-              make updates to the Application after you download the Application. These updates will
-              be made available to App Users from the third party from whom you received the
-              Application license, e.g., the Apple App Store or Google Play (each, an <strong>“App
-                Store”</strong>). You will have the ability, at your option, to download any updates
-              to the Application that we make freely available through such channels. We do not
-              require you to install any updates in order for you to continue using the Application
-              after we make such updates available. This is because we do not retain any information
-              about you when you download the Application. Therefore, we will not know whether you
-              have installed any such updates. Accordingly, you acknowledge and agree that if you
-              elect NOT to install available updates, the Application may not operate in accordance
-              with publicly available documentation regarding the features and functionality of the
-              Application, which documentation may be updated after the time you originally
-              downloaded it. In addition, you may need to update third-party software from time to
-              time in order to use the Application. Any updates issued by PCI and installed by you
-              shall be deemed the Application and shall be governed by this Safe Places EULA or any
-              subsequent end user license agreement accompanying the update.
-
-            <li><strong>Necessary Equipment and Software.</strong> You must provide all equipment
-              and software necessary to download and use the Application and to connect to any third
-              party services or sites, including but not limited to, a mobile device that is
-              suitable to connect with and use the Application. You are solely responsible for any
-              fees, including Internet connection or mobile fees, that you incur when accessing the
-              Application.
-
-            <li><strong>Responsibility for Location History and Other Data Collected and Stored by
-                You. </strong> PCI has no access to the Location History or any other data you
-              collect, receive and store in the installed Application or otherwise on your mobile
-              device. Therefore, PCI has no responsibility or liability for the deletion or accuracy
-              of the Location History or other data you collect, receive or store in the Application
-              or the failure to store, transmit or receive transmission of Location History or other
-              data; or the security, privacy, storage, or transmission of other communications
-              originating with or involving use of the Application.
-            </li>
-          </ol>
-
-        <li><strong>OWNERSHIP.</strong>
-          <ol>
-
-            <li>
-              <strong>Application.</strong> Except with respect to your Location History and other
-              data you may collect, retrieve from third parties and store in the Application on your
-              device, you agree that PCI and its suppliers own all rights, title and interest in and
-              to the Application. You will not remove, alter or obscure any copyright, trademark,
-              service mark or other proprietary rights notices incorporated in or accompanying the
-              Application.
-
-            <li><strong>Trademarks.</strong> COVID Safe Paths and all related graphics, logos,
-              service marks and trade names used on or in connection with the Application or in
-              connection therewith are the trademarks of PCI and may not be used without permission
-              in connection with your, or any third-party, products or services. Other trademarks,
-              service marks and trade names that may appear on or in the Application are the
-              property of their respective owners.
-            </li>
-          </ol>
-
-        <li><strong>COLLECTION AND USE OF YOUR PERSONAL INFORMATION. </strong>You acknowledge that
-          the Application may collect personal information about you (through your choice to store
-          information in the Application or through automatic technology tools), including your
-          Location History. You acknowledge that the Application may provide you with opportunities
-          to share personal information about yourself, including your Location History with others.
-          All personal information in connection with this Application is subject to our Privacy
-          Policy. By downloading, installing, using, and providing personal information to or
-          through this Application, you consent to all actions taken by us with respect to your
-          personal information in compliance with the Privacy Policy. For some features of the
-          Application, specific consent is required. In addition, you may choose to disclose,
-          through other means not associated with the Application, any part of your personal
-          information to family members, doctors, health care providers, governmental agencies, or
-          other individuals or entities. We recommend that you make your choices regarding sharing
-          your personal information, through the Application or otherwise, carefully. We will have
-          no liability for any consequences that may result because you have released or shared
-          information, through the Application or otherwise, with a third party.
-
-        <li><strong>FEEDBACK</strong>. If you provide PCI with any ideas, suggestions, documents,
-          and/or proposals (<strong>“Feedback”</strong>) via email or another means, you do so at
-          your own risk and you acknowledge and agree that PCI has no obligations (including without
-          limitation obligations of confidentiality) with respect to such Feedback. You represent
-          and warrant that you have all rights necessary to submit the Feedback. You hereby grant to
-          PCI a fully paid, royalty-free, perpetual, irrevocable, worldwide, non-exclusive, and
-          fully sublicensable right and license to use, reproduce, perform, display, distribute,
-          adapt, modify, re-format, create derivative works of, and otherwise commercially or
-          non-commercially exploit in any manner, any and all Feedback, and to sublicense the
-          foregoing rights, in connection with the operation and maintenance of the Application, any
-          other PCI products or services, or PCI’s business.
-
-        <li><strong>APP STORES. </strong>You acknowledge and agree that the availability of the
-          Application is dependent on the App Store from whom you received the Application license.
-          You acknowledge that this Agreement is between you and PCI and not with the App Store.
-          PCI, not the App Store, is solely responsible for the Application, including the content
-          PCI makes available therein, and the maintenance, support services, and warranty therefor,
-          and addressing any claims relating thereto (e.g., product liability, legal compliance or
-          intellectual property infringement). In order to use the Application, you must have access
-          to a wireless network, and you agree to pay all fees associated with such access. You also
-          agree to pay all fees (if any) charged by the App Store in connection with the
-          Application. You agree to comply with, and your license to use the Application is
-          conditioned upon your compliance with all terms of agreement imposed by the applicable App
-          Store when using the Application. You acknowledge that the App Store (and its
-          subsidiaries) are third-party beneficiaries of this Agreement and will have the right to
-          enforce it.
-
-        <li><strong>FEES. </strong>No fees shall be payable under this Agreement for the rights
-          granted under this Agreement. You acknowledge and agree that this fee arrangement is made
-          in consideration for the mutual covenants set forth in this Agreement, including your
-          obligations hereunder, and the disclaimers, exclusions, and limitations of liability set
-          forth herein.
-
-        <li><strong>INDEMNIFICATION. </strong>You agree to indemnify and hold PCI, its parents,
-          subsidiaries, affiliates, officers, employees, volunteers, agents, partners, suppliers,
-          and licensors (each, a “<strong>PCI Party</strong>” and collectively, the <strong>“PCI
-            Parties”</strong>) harmless from any losses, costs, liabilities and expenses (including
-          reasonable attorneys’ fees) relating to or arising out of any and all of the following:
-          (a) your use of, or inability to use the Application; (b) your violation of this
-          Agreement; (c) your violation of any rights of another party; or (d) your violation of any
-          applicable laws, rules or regulations. PCI reserves the right, at its own cost, to assume
-          the exclusive defense and control of any matter otherwise subject to indemnification by
-          you, in which event you will fully cooperate with PCI in asserting any available defenses.
-          This provision does not require you to indemnify any of the PCI Parties for any
-          unconscionable commercial practice by such party or for such party’s fraud, deception,
-          false promise, misrepresentation or concealment, suppression or omission of any material
-          fact in connection with the Application provided hereunder. You agree that the provisions
-          in this section will survive any termination of this Agreement and/or your use of or
-          access to Application.
-
-        <li><strong>DISCLAIMER OF WARRANTIES AND CONDITIONS.</strong>
-          <ol>
-
-            <li>
-              <strong>As Is.</strong> YOU EXPRESSLY UNDERSTAND AND AGREE THAT TO THE EXTENT
-              PERMITTED BY APPLICABLE LAW, YOUR USE OF THE APPLICATION IS AT YOUR SOLE RISK, AND THE
-              APPLICATION IS PROVIDED ON AN “AS IS” AND “AS AVAILABLE” BASIS, WITH ALL FAULTS. THE
-              PCI PARTIES EXPRESSLY DISCLAIM ALL WARRANTIES, REPRESENTATIONS, AND CONDITIONS OF ANY
-              KIND, WHETHER EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-              WARRANTIES OR CONDITIONS OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-              NON-INFRINGEMENT ARISING FROM USE OF THE APPLICATION.
-              <ol>
-
-                <li>
-                  THE PCI PARTIES MAKE NO WARRANTY, REPRESENTATION OR CONDITION THAT: (1) THE
-                  APPLICATION OR ITS FEATURES WILL MEET YOUR REQUIREMENTS; (2) YOUR USE OF THE
-                  APPLICATION WILL BE UNINTERRUPTED, TIMELY, SECURE OR ERROR-FREE; OR (3) THE
-                  RESULTS THAT MAY BE OBTAINED FROM USE OF THE APPLICATION WILL BE ACCURATE OR
-                  RELIABLE.
-
-                <li>ANY CONTENT DOWNLOADED FROM OR OTHERWISE ACCESSED THROUGH THE APPLICATION IS
-                  ACCESSED AT YOUR OWN RISK, AND YOU SHALL BE SOLELY RESPONSIBLE FOR ANY DAMAGE TO
-                  YOUR PROPERTY, INCLUDING, BUT NOT LIMITED TO, YOUR COMPUTER SYSTEM AND ANY DEVICE
-                  YOU USE TO ACCESS THE APPLICATION, OR ANY OTHER LOSS THAT RESULTS FROM ACCESSING
-                  SUCH CONTENT.
-
-                <li>THE AVAILABILITY OF THE APPLICATION AND ITS FEATURES MAY BE SUBJECT TO DELAYS,
-                  CANCELLATIONS AND OTHER DISRUPTIONS. PCI MAKES NO WARRANTY, REPRESENTATION OR
-                  CONDITION WITH RESPECT TO THE APPLICATION OR ITS FEATURES, INCLUDING BUT NOT
-                  LIMITED TO, THE QUALITY, EFFECTIVENESS, REPUTATION AND OTHER CHARACTERISTICS
-                  THEREOF.
-
-                <li>NO ADVICE OR INFORMATION, WHETHER ORAL OR WRITTEN, OBTAINED FROM PCI OR THROUGH
-                  THE APPLICATION WILL CREATE ANY WARRANTY NOT EXPRESSLY MADE HEREIN.
-
-                <li>FROM TIME TO TIME, PCI MAY OFFER NEW “BETA” FEATURES OR TOOLS WITH WHICH ITS
-                  USERS MAY EXPERIMENT. SUCH FEATURES OR TOOLS ARE OFFERED SOLELY FOR EXPERIMENTAL
-                  PURPOSES AND WITHOUT ANY WARRANTY OF ANY KIND, AND MAY BE MODIFIED OR DISCONTINUED
-                  AT PCI’S SOLE DISCRETION. THE PROVISIONS OF THIS SECTION APPLY WITH FULL FORCE TO
-                  SUCH FEATURES OR TOOLS.
-                </li>
-              </ol>
-
-            <li><strong>NOT INTENDED AS MEDICAL ADVICE.</strong> YOU ACKNOWLEDGE THAT THE
-              INFORMATION IN THE APPLICATION IS PROVIDED FOR GENERAL INFORMATIONAL PURPOSES ONLY. IT
-              IS NOT INTENDED AS MEDICAL ADVICE OF ANY KIND NOR IS IT INTENDED TO DIAGNOSE, TREAT,
-              CURE OR PREVENT ANY DISEASE OR MEDICAL CONDITION. THE INFORMATION PRESENTED IN THE
-              APPLICATION SHOULD NOT BE INTERPRETED OR CONSTRUED IN ANY WAY AS A REPLACEMENT OR
-              SUBSTITUTE FOR MEDICAL ADVICE PROVIDED BY YOUR DOCTOR OR OTHER QUALIFIED HEALTHCARE
-              PROVIDER. YOU SHOULD NOT DISREGARD, AVOID OR DELAY OBTAINING MEDICAL ADVICE OR
-              TREATMENT FROM YOUR DOCTOR OR OTHER QUALIFIED HEALTHCARE PROVIDER DUE TO ANY
-              INFORMATION PROVIDED IN THE APPLICATION. UNDER NO CIRCUMSTANCES SHOULD YOU ALTER YOUR
-              EXISTING MEDICAL TREATMENT, MEDICATION REGIMEN, OR ANY OTHER RELATED HEALTHCARE
-              ACTIVITIES BASED ON ANY INFORMATION PROVIDED IN THE APPLICATION. IT IS IMPORTANT FOR
-              YOU TO DISCUSS YOUR TREATMENT OPTIONS, AND ANY QUESTIONS THAT YOU MAY HAVE, WITH YOUR
-              DOCTOR OR OTHER QUALIFIED HEALTHCARE PROVIDER.
-
-            <li>In making the Application available for download, PCI’s goal is to provide
-              individuals with a useful tool for contact tracing. However, the utility of the
-              Application’s features is dependent upon a number of factors that are outside the
-              control of PCI, such as the reliability of GPS sensors, whether individuals are
-              carrying their mobile devices, as well as the accuracy, reliability, availability,
-              effectiveness or correct use of individual’s mobile devices and GPS sensors, all of
-              which are used to create Location History, and for any Publicly Available Safe Places
-              Data that you may upload into your Application from third party source, the accuracy
-              and completeness of such data. Your Location History or other data may be unavailable,
-              inaccurate or incomplete. Use of the Application should not replace your good judgment
-              and common sense.
-
-            <li><strong>No Liability for Conduct of Third Parties.</strong> YOU ACKNOWLEDGE AND
-              AGREE THAT PCI PARTIES ARE NOT LIABLE, AND YOU AGREE NOT TO SEEK TO HOLD PCI PARTIES
-              LIABLE, FOR THE CONDUCT OR OMISSIONS OF THIRD PARTIES, INCLUDING THE ACTIONS OF ANY
-              THIRD PARTY OPERATING A THIRD PARTY SAFE PLACES WEB APP OR ANY GOVERNMENTAL AGENCY
-              WITH WHICH YOU CHOOSE TO INTERACT IN CONNECTION WITH YOUR USE OF THE APPLICATION, AND
-              THAT THE RISK OF INJURY FROM SUCH THIRD PARTIES RESTS ENTIRELY WITH YOU.
-            </li>
-          </ol>
-
-        <li><strong>LIMITATION OF LIABILITY.</strong>
-          <ol>
-
-            <li>
-              <strong>Disclaimer of Certain Damages.</strong> YOU UNDERSTAND AND AGREE THAT IN NO
-              EVENT SHALL THE PCI PARTIES BE LIABLE FOR ANY LOSS OF PROFITS, PERSONAL INJURY,
-              PROPERTY DAMAGE, WRONGFUL DEATH, REVENUE OR DATA, INDIRECT, INCIDENTAL, SPECIAL, OR
-              CONSEQUENTIAL DAMAGES, OR DAMAGES OR COSTS DUE TO LOSS OF PRODUCTION OR USE, BUSINESS
-              INTERRUPTION, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, IN EACH CASE WHETHER OR NOT
-              PCI HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES, ARISING OUT OF OR IN
-              CONNECTION WITH THIS AGREEMENT, ON ANY THEORY OF LIABILITY, RESULTING FROM: (1) THE
-              USE OR INABILITY TO USE THE APPLICATION OR ANY OF ITS ADVERTISED FEATURES; (2)
-              UNAUTHORIZED ACCESS TO OR ALTERATION OF YOUR TRANSMISSIONS OR DATA; OR (3) ANY OTHER
-              MATTER RELATED TO THE APPLICATION, WHETHER BASED ON WARRANTY, COPYRIGHT, CONTRACT,
-              TORT (INCLUDING NEGLIGENCE), OR ANY OTHER LEGAL THEORY. THE FOREGOING CAP ON LIABILITY
-              SHALL NOT APPLY TO LIABILITY OF A PCI PARTY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY
-              A PCI PARTY’S NEGLIGENCE; OR FOR (B) ANY INJURY CAUSED BY A PCI PARTY’S FRAUD OR
-              FRAUDULENT MISREPRESENTATION.
-
-            <li><strong>Cap on Liability.</strong> TO THE MAXIMUM EXTENT PERMITTED BY LAW,
-              NOTWITHSTANDING ANYTHING TO THE CONTRARY CONTAINED HEREIN, OUR LIABILITY TO YOU FOR
-              ANY DAMAGES ARISING FROM OR RELATED TO THESE TERMS OF USE (FOR ANY CAUSE WHATSOEVER
-              AND REGARDLESS OF THE FORM OF THE ACTION), WILL AT ALL TIMES BE LIMITED TO A MAXIMUM
-              OF FIFTY US DOLLARS (U.S. $50). THE EXISTENCE OF MORE THAN ONE CLAIM WILL NOT ENLARGE
-              THIS LIMIT. YOU AGREE THAT OUR SUPPLIERS WILL HAVE NO LIABILITY OF ANY KIND ARISING
-              FROM OR RELATING TO THESE TERMS OF USE.
-
-            <li><strong>Your Data.</strong> EXCEPT FOR PCI’S OBLIGATIONS TO PROTECT YOUR PERSONAL
-              DATA AS SET FORTH IN THE PCI’S PRIVACY POLICY, PCI ASSUMES NO RESPONSIBILITY FOR THE
-              TIMELINESS, DELETION, MIS-DELIVERY OR FAILURE TO STORE ANY CONTENT (INCLUDING YOUR
-              LOCATION HISTORY), USER COMMUNICATIONS OR PERSONALIZATION SETTINGS.
-
-            <li><strong>Basis of the Bargain.</strong> THE LIMITATIONS OF DAMAGES SET FORTH ABOVE
-              ARE FUNDAMENTAL ELEMENTS OF THE BASIS OF THE BARGAIN BETWEEN PCI AND YOU.
-            </li>
-          </ol>
-
-        <li><strong>REMEDIES.</strong>
-          <ol>
-
-            <li>
-              <strong>Violations.</strong> If PCI becomes aware of any possible violations by you of
-              this Agreement, PCI reserves the right to investigate such violations. If, as a result
-              of the investigation, PCI believes that criminal activity has occurred, PCI reserves
-              the right to refer the matter to, and to cooperate with, any and all applicable legal
-              authorities. PCI is entitled, except to the extent prohibited by applicable law, to
-              disclose any information or materials you provide to PCI in connection with your use
-              of the Application, to (a) comply with applicable laws, legal process or governmental
-              request; (b) enforce these Terms of Use, (c) respond to your requests for customer
-              service, or (d) protect the rights, property or personal safety of PCI or the public,
-              and all enforcement or other government officials, as PCI, in its sole discretion
-              believes to be necessary or appropriate.
-            </li>
-          </ol>
-
-        <li><strong>TERM AND TERMINATION. </strong>
-          <ol>
-
-            <li>
-              <strong>Term.</strong> This Agreement commences on the date when you accept them (as
-              described in the preamble above) and remain in full force and effect while you use the
-              Application, unless terminated earlier in accordance with this Agreement.
-
-            <li><strong>Prior Use. </strong> Notwithstanding the foregoing, you hereby acknowledge
-              and agree that this Agreement commenced on the earlier to occur of (a) the date you
-              first used the Application or (b) the date you accepted this Agreement and will remain
-              in full force and effect while you use the Application, unless earlier terminated in
-              accordance with this Agreement.
-
-            <li><strong>Termination by You. </strong>If you want to terminate this Agreement, you
-              may do so by deleting the Application from your mobile device.
-
-            <li><strong>Effect of Termination.</strong> Termination of this Agreement requires you
-              to delete the Application and cease all use of it. All provisions of this Agreement
-              which by their nature should survive, shall survive termination, including without
-              limitation, ownership provisions, warranty disclaimers, and limitation of liability.
-            </li>
-          </ol>
-
-        <li><strong>INTERNATIONAL USERS. </strong>The Application is intended solely for use in the
-          United States of America. PCI makes no representations that the Application is functional
-          in other locations. Those who access or use the Application from other countries do so at
-          their own risk and are responsible for use in compliance with local law.
-
-        <li><strong>DISPUTE RESOLUTION<em>. Please read the following arbitration agreement in this
-              Section (“</em>Arbitration Agreement<em>”) carefully.  It requires U.S. users to
-              arbitrate disputes with PCI and limits the manner in which you can seek relief from
-              us. </em></strong>
-          <ol>
-
-            <li>
-              <strong>Applicability of Arbitration Agreement<em>.</em></strong> You agree that any
-              dispute, claim, or request for relief relating in any way to your access or use of the
-              Application or to any aspect of your relationship with PCI, will be resolved by
-              binding arbitration, rather than in court, except that (1) you may assert claims or
-              seek relief in small claims court if your claims qualify,; and (2) you or PCI may seek
-              equitable relief in court for infringement or other misuse of intellectual property
-              rights (such as trademarks, trade dress, domain names, trade secrets, copyrights, and
-              patents). <strong>This Arbitration Agreement shall apply, without limitation, to all
-                disputes or claims and requests for relief that arose or were asserted before the
-                effective date of this Agreement or any prior version of this Agreement. </strong>
-
-            <li><strong>Arbitration Rules and Forum<em>. </em></strong> The Federal Arbitration Act
-              governs the interpretation and enforcement of this Arbitration Agreement. To begin an
-              arbitration proceeding, you must send a letter requesting arbitration and describing
-              your dispute or claim or request for relief to our registered agent Samuel Hoff c/o
-              Pierce & Mandell, P.C. 11 Beacon Street Suite 800, Boston MA 02108. The arbitration
-              will be conducted by JAMS, an established alternative dispute resolution
-              provider.  Disputes involving claims, counterclaims, or request for relief under
-              $250,000, not inclusive of attorneys’ fees and interest, shall be subject to JAMS’s
-              most current version of the Streamlined Arbitration Rules and procedures available at
-              http://www.jamsadr.com/rules-streamlined-arbitration/; all other disputes shall be
-              subject to JAMS’s most current version of the Comprehensive Arbitration Rules and
-              Procedures, available at http://www.jamsadr.com/rules-comprehensive-arbitration/.
-              JAMS’s rules are also available at www.jamsadr.com or by calling JAMS at 800-352-5267.
-              If JAMS is not available to arbitrate, the parties will select an alternative arbitral
-              forum. If the arbitrator finds that you cannot afford to pay JAMS’s filing,
-              administrative, hearing and/or other fees and cannot obtain a waiver from JAMS, PCI
-              will pay them for you. In addition, PCI will reimburse all such JAMS’s filing,
-              administrative, hearing and/or other fees for disputes, claims, or requests for relief
-              totaling less than $10,000 unless the arbitrator determines the claims are frivolous.
-              <p>
-                You may choose to have the arbitration conducted by telephone, based on written
-                submissions, or at another mutually agreed location. Any judgment on the award
-                rendered by the arbitrator may be entered in any court of competent jurisdiction.
-              </p>
-              <ol>
-
-                <li>
-                  <strong>Authority of Arbitrator</strong>.  The arbitrator shall have exclusive
-                  authority to (a) determine the scope and enforceability of this Arbitration
-                  Agreement and (b) resolve any dispute related to the interpretation,
-                  applicability, enforceability or formation of this Arbitration Agreement
-                  including, but not limited to, any assertion that all or any part of this
-                  Arbitration Agreement is void or voidable. The arbitration will decide the rights
-                  and liabilities, if any, of you and PCI. The arbitration proceeding will not be
-                  consolidated with any other matters or joined with any other cases or parties.
-                  The arbitrator shall have the authority to grant motions dispositive of all or
-                  part of any claim. The arbitrator shall have the authority to award monetary
-                  damages and to grant any non-monetary remedy or relief available to an individual
-                  under applicable law, the arbitral forum’s rules, and this Agreement (including
-                  the Arbitration Agreement). The arbitrator shall issue a written award and
-                  statement of decision describing the essential findings and conclusions on which
-                  the award is based, including the calculation of any damages awarded.  The
-                  arbitrator has the same authority to award relief on an individual basis that a
-                  judge in a court of law would have.  The award of the arbitrator is final and
-                  binding upon you and us.
-
-                <li><strong>Waiver of Jury Trial</strong>.  YOU AND PCI HEREBY WAIVE ANY
-                  CONSTITUTIONAL AND STATUTORY RIGHTS TO SUE IN COURT AND HAVE A TRIAL IN FRONT OF A
-                  JUDGE OR A JURY. You and PCI are instead electing that all disputes, claims, or
-                  requests for relief shall be resolved by arbitration under this Arbitration
-                  Agreement, except as specified in Section 13.1 above.  An arbitrator can award on
-                  an individual basis the same damages and relief as a court and must follow this
-                  Agreement as a court would. However, there is no judge or jury in arbitration, and
-                  court review of an arbitration award is subject to very limited review.
-
-                <li><strong>Waiver of Class or Other Non-Individualized Relief</strong>.  ALL
-                  DISPUTES, CLAIMS, AND REQUESTS FOR RELIEF WITHIN THE SCOPE OF THIS ARBITRATION
-                  AGREEMENT MUST BE ARBITRATED ON AN INDIVIDUAL BASIS AND NOT ON A CLASS OR
-                  COLLECTIVE BASIS, ONLY INDIVIDUAL RELIEF IS AVAILABLE, AND CLAIMS OF MORE THAN ONE
-                  CUSTOMER OR USER CANNOT BE ARBITRATED OR CONSOLIDATED WITH THOSE OF ANY OTHER
-                  CUSTOMER OR USER. If a decision is issued stating that applicable law precludes
-                  enforcement of any of this subsection’s limitations as to a given dispute, claim,
-                  or request for relief, then such aspect must be severed from the arbitration and
-                  brought into the State or Federal Courts located in the Commonwealth of
-                  Massachusetts. All other disputes, claims, or requests for relief shall be
-                  arbitrated.
-
-                <li><strong>30-Day Right to Opt Out</strong>. You have the right to opt out of the
-                  provisions of this Arbitration Agreement by sending written notice of your
-                  decision to opt out to: legal@pathcheck.org, within 30 days after first becoming
-                  subject to this Arbitration Agreement. Your notice must include your name and
-                  address, your email address, and an unequivocal statement that you want to opt out
-                  of this Arbitration Agreement. If you opt out of this Arbitration Agreement, all
-                  other parts of this Agreement will continue to apply to you. Opting out of this
-                  Arbitration Agreement has no effect on any other arbitration agreements that you
-                  may currently have, or may enter in the future, with us.
-
-                <li><strong>Severability<em>. </em></strong>Except as provided in subsection 13.5,
-                  if any part or parts of this Arbitration Agreement are found under the law to be
-                  invalid or unenforceable, then such specific part or parts shall be of no force
-                  and effect and shall be severed and the remainder of the Arbitration Agreement
-                  shall continue in full force and effect.
-
-                <li><strong>Survival of Agreement<em>. </em></strong>This Arbitration Agreement will
-                  survive the termination of your relationship with PCI.
-
-                <li><strong>Modification</strong>.<strong> </strong>Notwithstanding any provision in
-                  this Agreement to the contrary, we agree that if PCI makes any future material
-                  change to this Arbitration Agreement, you may reject that change within thirty
-                  (30) days of such change becoming effective by writing PCI at the following
-                  address: Path Check, Inc. PO Box 441621, Somerville MA 02144
-                </li>
-              </ol>
-
-            <li><strong>GENERAL PROVISIONS.</strong>
-              <ol>
-
-                <li>
-                  <strong>Electronic Communications.</strong> The communications between you and PCI
-                  may take place via electronic means, whether you send PCI e-mails, or whether PCI
-                  posts notices in the Application or through updates made to the Application in
-                  accordance with this Terms of Use or communicates with you via e-mail. For
-                  contractual purposes, you (a) consent to receive communications from PCI in an
-                  electronic form; and (b) agree that all terms and conditions, agreements, notices,
-                  disclosures, and other communications that PCI provides to you electronically
-                  satisfy any legal requirement that such communications would satisfy if it were to
-                  be in writing. The foregoing does not affect your statutory rights, including but
-                  not limited to the Electronic Signatures in Global and National Commerce Act at 15
-                  U.S.C. §7001 et seq. (“E-Sign”).
-
-                <li><strong>Release.</strong> You hereby release the PCI Parties and their
-                  successors from claims, demands, any and all losses, damages, rights, and actions
-                  of any kind, including personal injuries, death, and property damage, that is
-                  either directly or indirectly related to or arises from any interactions with or
-                  conduct of operators of Third Party Safe Places Web Apps, healthcare providers,
-                  governmental agencies, of any kind arising in connection with or as a result of
-                  this Agreement or your use of the Application. If you are a California resident,
-                  you hereby waive California Civil Code Section 1542, which states, “A general
-                  release does not extend to claims that the creditor or releasing party does not
-                  know or suspect to exist in his or her favor at the time of executing the release
-                  and that, if known by him or her, would have materially affected his or her
-                  settlement with the debtor or released party.” The foregoing release does not
-                  apply to any claims, demands, or any losses, damages, rights and actions of any
-                  kind, including personal injuries, death or property damage for any unconscionable
-                  commercial practice by a PCI Party or for such party’s fraud, deception, false,
-                  promise, misrepresentation or concealment, suppression or omission of any material
-                  fact in connection with the Application provided hereunder.
-
-                <li><strong>Assignment.</strong> This Agreement, and your rights and obligations
-                  hereunder, may not be assigned, subcontracted, delegated or otherwise transferred
-                  by you without PCI’s prior written consent, and any attempted assignment,
-                  subcontract, delegation, or transfer in violation of the foregoing will be null
-                  and void.
-
-                <li><strong>Force Majeure.</strong> PCI shall not be liable for any delay or failure
-                  to perform resulting from causes outside its reasonable control, including, but
-                  not limited to, acts of God, war, terrorism, riots, embargos, acts of civil or
-                  military authorities, fire, floods, accidents, strikes or shortages of
-                  transportation facilities, fuel, energy, labor or materials.
-
-                <li><strong>Questions, Complaints, Claims.</strong> If you have any questions,
-                  complaints or claims with respect to the Application, please contact us at:
-                  support@pathcheck.org.
-
-                <li><strong>Exclusive Venue.</strong> To the extent the parties are permitted under
-                  this Agreement to initiate litigation in a court, both you and PCI agree that all
-                  claims and disputes arising out of or relating to this Agreement will be litigated
-                  exclusively in the state or federal courts located in Boston, Massachusetts.
-
-                <li><strong>Governing Law </strong>THE TERMS AND ANY ACTION RELATED THERETO WILL BE
-                  GOVERNED AND INTERPRETED BY AND UNDER THE LAWS OF THE COMMONWEALTH OF
-                  MASSACHUSETTS, CONSISTENT WITH THE FEDERAL ARBITRATION ACT, WITHOUT GIVING EFFECT
-                  TO ANY PRINCIPLES THAT PROVIDE FOR THE APPLICATION OF THE LAW OF ANOTHER
-                  JURISDICTION. THE UNITED NATIONS CONVENTION ON CONTRACTS FOR THE INTERNATIONAL
-                  SALE OF GOODS DOES NOT APPLY TO THIS AGREEMENT.
-
-                <li><strong>Choice of Language.</strong> It is the express wish of the parties that
-                  this Agreement and all related documents have been drawn up in English.
-
-                <li><strong>Notice.</strong> You may give notice to PCI at the following address:
-                  Path Check, Inc. PO Box 441621, Somerville MA 02144. Such notice shall be deemed
-                  given when received by PCI by letter delivered by nationally recognized overnight
-                  delivery service or first class postage prepaid mail at the above address.
-
-                <li><strong>Waiver.</strong> Any waiver or failure to enforce any provision of this
-                  Agreement on one occasion will not be deemed a waiver of any other provision or of
-                  such provision on any other occasion.
-
-                <li><strong>Severability.</strong> If any portion of this Agreement is held invalid
-                  or unenforceable, that portion shall be construed in a manner to reflect, as
-                  nearly as possible, the original intention of the parties, and the remaining
-                  portions shall remain in full force and effect.
-
-                <li><strong>Export Control.</strong> You may not use, export, import, or transfer
-                  the Application except as authorized by U.S. law, the laws of the jurisdiction in
-                  which you obtained PCI Properties, and any other applicable laws. In particular,
-                  but without limitation, the Application may not be exported or re-exported (a)
-                  into any United States embargoed countries, or (b) to anyone on the U.S. Treasury
-                  Department’s list of Specially Designated Nationals or the U.S. Department of
-                  Commerce’s Denied Person’s List or Entity List. By using the Application, you
-                  represent and warrant that (y) you are not located in a country that is subject to
-                  a U.S. Government embargo, or that has been designated by the U.S. Government as a
-                  “terrorist supporting” country and (z) you are not listed on any U.S. Government
-                  list of prohibited or restricted parties. You also will not use the Application
-                  for any purpose prohibited by U.S. law, including the development, design,
-                  manufacture or production of missiles, nuclear, chemical or biological weapons.
-                  You acknowledge and agree that products, services or technology provided by PCI
-                  are subject to the export control laws and regulations of the United States. You
-                  shall comply with these laws and regulations and shall not, without prior U.S.
-                  government authorization, export, re-export, or transfer PCI products, services or
-                  technology, either directly or indirectly, to any country in violation of such
-                  laws and regulations.
-
-                <li><strong>Accessing and Downloading the Application from iTunes.</strong> The
-                  following applies to any App Store Sourced Application accessed through or
-                  downloaded from the Apple App Store:
-                  <ol>
-
-                    <li>
-                      You acknowledge and agree that (i) this Agreement is concluded between you and
-                      PCI only, and not Apple, and (ii) PCI, not Apple, is solely responsible for
-                      the App Store Sourced Application and content thereof. Your use of the App
-                      Store Sourced Application must comply with the App Store Terms of Service.
-
-                    <li>You acknowledge that Apple has no obligation whatsoever to furnish any
-                      maintenance and support services with respect to the App Store Sourced
-                      Application.
-
-                    <li>In the event of any failure of the App Store Sourced Application to conform
-                      to any applicable warranty, you may notify Apple, and Apple will refund the
-                      purchase price for the App Store Sourced Application to you and to the maximum
-                      extent permitted by applicable law, Apple will have no other warranty
-                      obligation whatsoever with respect to the App Store Sourced Application. As
-                      between PCI and Apple, any other claims, losses, liabilities, damages, costs
-                      or expenses attributable to any failure to conform to any warranty will be the
-                      sole responsibility of PCI.
-
-                    <li>You and PCI acknowledge that, as between PCI and Apple, Apple is not
-                      responsible for addressing any claims you have or any claims of any third
-                      party relating to the App Store Sourced Application or your possession and use
-                      of the App Store Sourced Application, including, but not limited to: (i)
-                      product liability claims; (ii) any claim that the App Store Sourced
-                      Application fails to conform to any applicable legal or regulatory
-                      requirement; and (iii) claims arising under consumer protection or similar
-                      legislation.
-
-                    <li>You and PCI acknowledge that, in the event of any third-party claim that the
-                      App Store Sourced Application or your possession and use of that App Store
-                      Sourced Application infringes that third party’s intellectual property rights,
-                      as between PCI and Apple, PCI, not Apple, will be solely responsible for the
-                      investigation, defense, settlement and discharge of any such intellectual
-                      property infringement claim to the extent required by this Agreement.
-
-                    <li>You and PCI acknowledge and agree that Apple, and Apple’s subsidiaries, are
-                      third-party beneficiaries of this Agreement as related to your license of the
-                      App Store Sourced Application, and that, upon your acceptance of the terms and
-                      conditions of this Agreement, Apple will have the right (and will be deemed to
-                      have accepted the right) to enforce this Agreement as related to your license
-                      of the App Store Sourced Application against you as a third-party beneficiary
-                      thereof.
-
-                    <li>Without limiting any other terms of this Agreement, you must comply with all
-                      applicable third-party terms of agreement when using the App Store Sourced
-                      Application.
-                    </li>
-                  </ol>
-
-                <li><strong>Consumer Complaints.</strong> In accordance with California Civil Code
-                  §1789.3, you may report complaints to the Complaint Assistance Unit of the
-                  Division of Consumer Services of the California Department of Consumer Affairs by
-                  contacting them in writing at 1625 North Market Blvd., Suite N 112, Sacramento, CA
-                  95834, or by telephone at (800) 952-5210.
-
-                <li><strong>Entire Agreement.</strong> This Agreement is the final, complete and
-                  exclusive agreement of the parties with respect to the subject matter hereof and
-                  supersedes and merges all prior discussions between the parties with respect to
-                  such subject matter.
+    <p><strong>Terms of Use</strong></p>
+    <p><strong>Last Updated Date: April 23, 2020</strong></p>
+    <p>PLEASE READ THIS TERMS OF USE AGREEMENT (THE </strong><strong>&ldquo;TERMS
+            OF USE&rdquo; </strong>OR </strong><strong>&ldquo;AGREEMENT&rdquo;</strong><span
+            class="c1">) CAREFULLY. &nbsp;THE SAFE PATH MOBILE APPLICATION (THE &ldquo;</strong><span
+            class="c3 c0">APPLICATION&rdquo;</strong>), AND THE FEATURES AND INFORMATION IN IT ARE
+            CONTROLLED BY PATH CHECK, INC. (&ldquo;</strong><strong>PCI</strong>&rdquo;).
+            &nbsp;THESE TERMS OF USE GOVERN THE USE OF THE APPLICATION AND APPLY TO ALL USERS USING THE APPLICATION IN
+            ANY WAY, INCLUDING THE FEATURES THEREIN. BY CLICKING ON THE &ldquo;I ACCEPT&rdquo; BUTTON AND/OR DOWNLOADING
+            THE APPLICATION, YOU REPRESENT THAT (1) YOU HAVE READ, UNDERSTAND, AND AGREE TO BE BOUND BY THE TERMS OF
+            USE, (2) YOU ARE OF LEGAL AGE TO FORM A BINDING CONTRACT WITH PCI, AND (3) YOU HAVE THE AUTHORITY TO ENTER
+            INTO THE TERMS OF USE. &nbsp;</strong><strong>IF YOU DO NOT AGREE TO BE BOUND BY THE TERMS OF USE,
+            YOU MAY NOT ACCESS OR USE THE APPLICATION</strong>.</strong></p>
+    <p><strong>PLEASE BE AWARE THAT SECTION 13 OF THIS AGREEMENT, BELOW, CONTAINS PROVISIONS
+            GOVERNING HOW DISPUTES THAT YOU AND WE HAVE AGAINST EACH OTHER ARE RESOLVED, INCLUDING, WITHOUT LIMITATION,
+            ANY DISPUTES THAT AROSE OR WERE ASSERTED PRIOR TO THE EFFECTIVE DATE OF THIS AGREEMENT. IN PARTICULAR, IT
+            CONTAINS AN ARBITRATION AGREEMENT WHICH WILL, WITH LIMITED EXCEPTIONS, REQUIRE DISPUTES BETWEEN US TO BE
+            SUBMITTED TO BINDING AND FINAL ARBITRATION. &nbsp;UNLESS YOU OPT OUT OF THE ARBITRATION AGREEMENT: (1) YOU
+            WILL ONLY BE PERMITTED TO PURSUE DISPUTES OR CLAIMS AND SEEK RELIEF AGAINST US ON AN INDIVIDUAL BASIS, NOT
+            AS A PLAINTIFF OR CLASS MEMBER IN ANY CLASS OR REPRESENTATIVE ACTION OR PROCEEDING; AND (2) YOU ARE WAIVING
+            YOUR RIGHT TO PURSUE DISPUTES OR CLAIMS AND SEEK RELIEF IN A COURT OF LAW AND TO HAVE A JURY TRIAL.
+            &nbsp;</strong></p>
+    <p><strong>ANY DISPUTE, CLAIM OR REQUEST FOR RELIEF RELATING IN ANY WAY TO YOUR USE OF THE
+            APPLICATION WILL BE GOVERNED AND INTERPRETED BY AND UNDER THE LAWS OF THE COMMONWEALTH OF MASSACHUSETTS,
+            CONSISTENT WITH THE FEDERAL ARBITRATION ACT, WITHOUT GIVING EFFECT TO ANY PRINCIPLES THAT PROVIDE FOR THE
+            APPLICATION OF THE LAW OF ANY OTHER JURISDICTION. &nbsp;THE UNITED NATIONS CONVENTION ON CONTRACTS FOR THE
+            INTERNATIONAL SALE OF GOODS IS EXPRESSLY EXCLUDED FROM THIS AGREEMENT. </strong></p>
+    <p>PLEASE NOTE THAT </strong>THIS AGREEMENT IS SUBJECT TO CHANGE BY PCI
+            IN ITS SOLE DISCRETION AT ANY TIME</strong>. &nbsp;When changes are made, PCI will make a new
+            copy of the Terms of Use available within the Application. &nbsp;We will also update the &ldquo;Last
+            Updated&rdquo; date at the top of the Terms of Use. &nbsp;Your continued use of the Application after a
+            change to the Terms of Use is made constitutes acceptance. &nbsp;PLEASE REGULARLY CHECK THE APPLICATION TO
+            VIEW THE MOST CURRENT TERMS.</strong></p>
+    <p><strong>1. </strong><strong>USE OF THE APPLICATION.</strong>&nbsp;
+        </strong></p>
+    <p><strong>1.1 </strong><strong>Definitions</strong>. &nbsp;As used in
+            these Terms of Use, the following definitions apply:</strong></p>
+    <p>&ldquo;</strong><strong>App User</strong>&rdquo; means an
+            individual natural person who has downloaded the Application under these Terms of Use.</strong></p>
+    <p>&ldquo;</strong><strong>Location History</strong>&rdquo;
+            means location data collected from an App User&rsquo;s mobile device leveraging GPS, Bluetooth and/or other
+            features or software, that the App User elects to have recorded and stored within the Application installed
+            on the App User&rsquo;s mobile device.</strong></p>
+    <p>&ldquo;</strong><strong>Publicly Available Safe Places Data</strong><span
+            class="c1">&rdquo; means anonymized maps of public places where individuals diagnosed with Covid-19 have
+            visited and data files of times they visited such places, as compiled and created by a third party, and made
+            available via such third party&rsquo;s Third Party Safe Places Web App.</strong></p>
+    <p>&ldquo;</strong><strong>Safe Places Software</strong>&rdquo;
+            means open-source software, available at </strong><span class="c8"><a class="c11"
+                href="https://www.google.com/url?q=https://github.com/tripleblindmarket/safe-places&amp;sa=D&amp;ust=1587722145899000">https://github.com/tripleblindmarket/safe-places</a></strong><span
+            class="c1">, that facilitates contact tracing and related tasks, and is designed for use by third parties,
+            such as government agencies. </strong></p>
+    <p>&ldquo;</strong><strong>Third Party Safe Places Web App</strong><span
+            class="c1">&rdquo; means a web-based application owned and operated by a third party, such as a government
+            agency, that employs Safe Places Software to, among other things, publish Publicly Available Safe Places
+            Data.</strong></p>
+    <p><strong>1.2 </strong><strong>Application Features and Functionality.</strong><span
+            class="c1">&nbsp; The Application is designed to enable App Users, </strong><span class="c13 c16">at their
+            option</strong>: (a) to record their Location History and to store such data locally in the
+            Application downloaded to their mobile device, (b) to access Publicly Available Safe Places Data from one or
+            more Third Party Safe Places Web Apps and download it to the Safe Paths App downloaded on their mobile
+            device, and (c) to share their stored Location History with third parties that they choose. &nbsp;</strong>
+    </p>
+    <p><strong>1.3 </strong><strong>Application License. </strong>The
+            Application and the information and content available therein are protected by copyright laws throughout the
+            world. &nbsp;Subject to your compliance with this Agreement, PCI grants you a limited non-exclusive,
+            non-transferable, non-sublicensable, revocable license to download, install and use a copy of the
+            Application on a single mobile device or computer that you own or control and to run such copy of the
+            Application solely for your own personal or internal business purposes. &nbsp;Certain components or
+            libraries included in or bundled with the Application constitute open source software and are licensed under
+            open source licenses. &nbsp;To the extent required by such open source licenses, the terms of such licenses
+            will apply in lieu of the terms of this Section 1.3, solely with respect to those components or libraries
+            that are licensed under such open source licenses. &nbsp;For a copy of such open source licenses, visit
+        </strong><span class="c8"><a class="c11"
+                href="https://www.google.com/url?q=https://github.com/tripleblindmarket/covid-safe-paths/blob/develop/LICENSE&amp;sa=D&amp;ust=1587722145900000">https://github.com/tripleblindmarket/covid-safe-paths/blob/develop/LICENSE</a></strong><span
+            class="c1">. &nbsp;Furthermore, with respect to any Application accessed through or downloaded from the
+            Apple App Store (an</strong><strong>&nbsp;&ldquo;App Store Sourced Application&rdquo;</strong><span
+            class="c1">), you will only use the App Store Sourced Application (a) on an Apple-branded product that runs
+            the iOS (Apple&rsquo;s proprietary operating system) and (b) as permitted by the &ldquo;Usage Rules&rdquo;
+            set forth in the Apple App Store Terms of Service. Notwithstanding the first sentence in this section, with
+            respect to any Application accessed through or downloaded from the Google Play store (a &ldquo;</strong><span
+            class="c3 c0">Google Play Sourced Application</strong>&rdquo;), you may have additional
+            license rights with respect to use of the Application on a shared basis within your designated family
+            group.</strong></p>
+    <p id="h.gjdgxs"><strong>1.4 </strong><strong>Updates.</strong>&nbsp;
+            You understand that to keep the Application most useful for App Users and to accommodate bug fixes and other
+            technological changes, PCI may make updates to the Application after you download the Application.
+            &nbsp;These updates will be made available to App Users from the third party from whom you received the
+            Application license, e.g., the Apple App Store or Google Play (each, an </strong><span
+            class="c3 c0">&ldquo;App Store&rdquo;</strong>). &nbsp;You will have the ability, at your
+            option, to download any updates to the Application that we make freely available through such channels.
+            &nbsp;We do not require you to install any updates in order for you to continue using the Application after
+            we make such updates available. &nbsp;This is because we do not retain any information about you when you
+            download the Application. &nbsp;Therefore, we will not know whether you have installed any such updates.
+            &nbsp;Accordingly, you acknowledge and agree that if you elect NOT to install available updates, the
+            Application may not operate in accordance with publicly available documentation regarding the features and
+            functionality of the Application, which documentation may be updated after the time you originally
+            downloaded it. &nbsp;In addition, you may need to update third-party software from time to time in order to
+            use the Application. &nbsp;Any updates issued by PCI and installed by you shall be deemed the Application
+            and shall be governed by this Safe Places EULA or any subsequent end user license agreement accompanying the
+            update.</strong></p>
+    <p><strong>1.5 </strong><strong>Necessary Equipment and Software.</strong><span
+            class="c1">&nbsp; You must provide all equipment and software necessary to download and use the Application
+            and to connect to any third party services or sites, including but not limited to, a mobile device that is
+            suitable to connect with and use the Application. &nbsp;You are solely responsible for any fees, including
+            Internet connection or mobile fees, that you incur when accessing the Application. &nbsp;</strong></p>
+    <p><strong>1.6 </strong><strong>Responsibility for Location History and Other Data
+            Collected and Stored by You. </strong>&nbsp;PCI has no access to the Location History or any
+            other data you collect, receive and store in the installed Application or otherwise on your mobile device.
+            &nbsp;Therefore, PCI has no responsibility or liability for the deletion or accuracy of the Location History
+            or other data you collect, receive or store in the Application or the failure to store, transmit or receive
+            transmission of Location History or other data; or the security, privacy, storage, or transmission of other
+            communications originating with or involving use of the Application. &nbsp;</strong></p>
+    <p><strong>2. </strong><strong>OWNERSHIP.</strong></p>
+    <p><strong>2.1 </strong><strong>Application.</strong>&nbsp; Except with
+            respect to your Location History and other data you may collect, retrieve from third parties and store in
+            the Application on your device, you agree that PCI and its suppliers own all rights, title and interest in
+            and to the Application. &nbsp;You will not remove, alter or obscure any copyright, trademark, service mark
+            or other proprietary rights notices incorporated in or accompanying the Application.</strong></p>
+    <p><strong>2.2 </strong><strong>Trademarks.</strong>&nbsp;COVID Safe
+            Paths and all related graphics, logos, service marks and trade names used on or in connection with the
+            Application or in connection therewith are the trademarks of PCI and may not be used without permission in
+            connection with your, or any third-party, products or services. &nbsp;Other trademarks, service marks and
+            trade names that may appear on or in the Application are the property of their respective owners.</strong></p>
+    <p><strong>3. </strong><strong>COLLECTION AND USE OF YOUR PERSONAL
+            INFORMATION.</strong><strong>&nbsp; </strong>You acknowledge that the Application
+            may collect personal information about you (through your choice to store information in the Application or
+            through automatic technology tools), including your Location History. &nbsp;You acknowledge that the
+            Application may provide you with opportunities to share personal information about yourself, including your
+            Location History with others. All personal information in connection with this Application is subject to our
+            Privacy Policy. By downloading, installing, using, and providing personal information to or through this
+            Application, you consent to all actions taken by us with respect to your personal information in compliance
+            with the Privacy Policy. &nbsp;For some features of the Application, specific consent is required. &nbsp;In
+            addition, you may choose to disclose, through other means not associated with the Application, any part of
+            your personal information to family members, doctors, health care providers, governmental agencies, or other
+            individuals or entities. &nbsp;We recommend that you make your choices regarding sharing your personal
+            information, through the Application or otherwise, carefully. &nbsp;We will have no liability for any
+            consequences that may result because you have released or shared information, through the Application or
+            otherwise, with a third party. &nbsp;</strong></p>
+    <p><strong>4. </strong><strong>FEEDBACK</strong>. &nbsp;If you provide
+            PCI with any ideas, suggestions, documents, and/or proposals (</strong><span
+            class="c3 c0">&ldquo;Feedback&rdquo;</strong>) via email or another means, you do so at your
+            own risk and you acknowledge and agree that PCI has no obligations (including without limitation obligations
+            of confidentiality) with respect to such Feedback. &nbsp;You represent and warrant that you have all rights
+            necessary to submit the Feedback. &nbsp;You hereby grant to PCI a fully paid, royalty-free, perpetual,
+            irrevocable, worldwide, non-exclusive, and fully sublicensable right and license to use, reproduce, perform,
+            display, distribute, adapt, modify, re-format, create derivative works of, and otherwise commercially or
+            non-commercially exploit in any manner, any and all Feedback, and to sublicense the foregoing rights, in
+            connection with the operation and maintenance of the Application, any other PCI products or services, or
+            PCI&rsquo;s &nbsp;business.</strong></p>
+    <p><strong>5. </strong><strong>APP STORES</strong><strong>.
+            &nbsp;</strong>You acknowledge and agree that the availability of the Application is
+            dependent on the App Store from whom you received the Application license. &nbsp;You acknowledge that this
+            Agreement is between you and PCI and not with the App Store. &nbsp;PCI, not the App Store, is solely
+            responsible for the Application, including the content PCI makes available therein, and the maintenance,
+            support services, and warranty therefor, and addressing any claims relating thereto (e.g., product
+            liability, legal compliance or intellectual property infringement). &nbsp;In order to use the Application,
+            you must have access to a wireless network, and you agree to pay all fees associated with such access.
+            &nbsp;You also agree to pay all fees (if any) charged by the App Store in connection with the Application.
+            &nbsp;You agree to comply with, and your license to use the Application is conditioned upon your compliance
+            with all terms of agreement imposed by the applicable App Store when using the Application. You acknowledge
+            that the App Store (and its subsidiaries) are third-party beneficiaries of this Agreement and will have the
+            right to enforce it.</strong></p>
+    <p><strong>6. </strong><strong>FEES. &nbsp;</strong>No fees shall be
+            payable under this Agreement for the rights granted under this Agreement. You acknowledge and agree that
+            this fee arrangement is made in consideration for the mutual covenants set forth in this Agreement,
+            including your obligations hereunder, and the disclaimers, exclusions, and limitations of liability set
+            forth herein.</strong></p>
+    <p><strong>7. </strong><strong>INDEMNIFICATION. &nbsp;</strong>You
+            agree to indemnify and hold PCI, its parents, subsidiaries, affiliates, officers, employees, volunteers,
+            agents, partners, suppliers, and licensors (each, a &ldquo;</strong><strong>PCI Party</strong><span
+            class="c1">&rdquo; and collectively, the </strong><strong>&ldquo;PCI Parties&rdquo;</strong><span
+            class="c1">) harmless from any losses, costs, liabilities and expenses (including reasonable
+            attorneys&rsquo; fees) relating to or arising out of any and all of the following: (a) your use of, or
+            inability to use the Application; (b) your violation of this Agreement; (c) your violation of any rights of
+            another party; or (d) your violation of any applicable laws, rules or regulations. &nbsp;PCI reserves the
+            right, at its own cost, to assume the exclusive defense and control of any matter otherwise subject to
+            indemnification by you, in which event you will fully cooperate with PCI in asserting any available
+            defenses. &nbsp;This provision does not require you to indemnify any of the PCI Parties for any
+            unconscionable commercial practice by such party or for such party&rsquo;s fraud, deception, false promise,
+            misrepresentation or concealment, suppression or omission of any material fact in connection with the
+            Application provided hereunder. You agree that the provisions in this section will survive any termination
+            of this Agreement and/or your use of or access to Application.</strong></p>
+    <p><strong>8. </strong><strong>DISCLAIMER OF WARRANTIES AND CONDITIONS.</strong></p>
+    <p><strong>8.1 </strong><strong>As Is.</strong>&nbsp;YOU EXPRESSLY
+            UNDERSTAND AND AGREE THAT TO THE EXTENT PERMITTED BY APPLICABLE LAW, YOUR USE OF THE APPLICATION IS AT YOUR
+            SOLE RISK, AND THE APPLICATION IS PROVIDED ON AN &ldquo;AS IS&rdquo; AND &ldquo;AS AVAILABLE&rdquo; BASIS,
+            WITH ALL FAULTS. &nbsp;THE PCI PARTIES EXPRESSLY DISCLAIM ALL WARRANTIES, REPRESENTATIONS, AND CONDITIONS OF
+            ANY KIND, WHETHER EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OR CONDITIONS OF
+            MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARISING FROM USE OF THE APPLICATION.
+            &nbsp;</strong></p>
+    <p><strong>(a) </strong>THE PCI PARTIES MAKE NO WARRANTY, REPRESENTATION OR
+            CONDITION THAT: (1) THE APPLICATION OR ITS FEATURES WILL MEET YOUR REQUIREMENTS; (2) YOUR USE OF THE
+            APPLICATION WILL BE UNINTERRUPTED, TIMELY, SECURE OR ERROR-FREE; OR (3) THE RESULTS THAT MAY BE OBTAINED
+            FROM USE OF THE APPLICATION WILL BE ACCURATE OR RELIABLE.</strong></p>
+    <p><strong>(b) </strong>ANY CONTENT DOWNLOADED FROM OR OTHERWISE ACCESSED THROUGH
+            THE APPLICATION IS ACCESSED AT YOUR OWN RISK, AND YOU SHALL BE SOLELY RESPONSIBLE FOR ANY DAMAGE TO YOUR
+            PROPERTY, INCLUDING, BUT NOT LIMITED TO, YOUR COMPUTER SYSTEM AND ANY DEVICE YOU USE TO ACCESS THE
+            APPLICATION, OR ANY OTHER LOSS THAT RESULTS FROM ACCESSING SUCH CONTENT.</strong></p>
+    <p><strong>(c) </strong>THE AVAILABILITY OF THE APPLICATION AND ITS FEATURES MAY
+            BE SUBJECT TO DELAYS, CANCELLATIONS AND OTHER DISRUPTIONS. &nbsp;PCI MAKES NO WARRANTY, REPRESENTATION OR
+            CONDITION WITH RESPECT TO THE APPLICATION OR ITS FEATURES, INCLUDING BUT NOT LIMITED TO, THE QUALITY,
+            EFFECTIVENESS, REPUTATION AND OTHER CHARACTERISTICS THEREOF.</strong></p>
+    <p><strong>(d) </strong>NO ADVICE OR INFORMATION, WHETHER ORAL OR WRITTEN,
+            OBTAINED FROM PCI OR THROUGH THE APPLICATION WILL CREATE ANY WARRANTY NOT EXPRESSLY MADE HEREIN.</strong></p>
+    <p><strong>(e) </strong>FROM TIME TO TIME, PCI MAY OFFER NEW &ldquo;BETA&rdquo;
+            FEATURES OR TOOLS WITH WHICH ITS USERS MAY EXPERIMENT. &nbsp;SUCH FEATURES OR TOOLS ARE OFFERED SOLELY FOR
+            EXPERIMENTAL PURPOSES AND WITHOUT ANY WARRANTY OF ANY KIND, AND MAY BE MODIFIED OR DISCONTINUED AT
+            PCI&rsquo;S SOLE DISCRETION. &nbsp;THE PROVISIONS OF THIS SECTION APPLY WITH FULL FORCE TO SUCH FEATURES OR
+            TOOLS.</strong></p>
+    <p><strong>8.2 </strong><strong>NOT INTENDED AS MEDICAL ADVICE.</strong><span
+            class="c1">&nbsp;YOU ACKNOWLEDGE THAT THE INFORMATION IN THE APPLICATION IS PROVIDED FOR GENERAL
+            INFORMATIONAL PURPOSES ONLY. IT IS NOT INTENDED AS MEDICAL ADVICE OF ANY KIND NOR IS IT INTENDED TO
+            DIAGNOSE, TREAT, CURE OR PREVENT ANY DISEASE OR MEDICAL CONDITION. &nbsp;THE INFORMATION PRESENTED IN THE
+            APPLICATION SHOULD NOT BE INTERPRETED OR CONSTRUED IN ANY WAY AS A REPLACEMENT OR SUBSTITUTE FOR MEDICAL
+            ADVICE PROVIDED BY YOUR DOCTOR OR OTHER QUALIFIED HEALTHCARE PROVIDER. &nbsp;YOU SHOULD NOT DISREGARD, AVOID
+            OR DELAY OBTAINING MEDICAL ADVICE OR TREATMENT FROM YOUR DOCTOR OR OTHER QUALIFIED HEALTHCARE PROVIDER DUE
+            TO ANY INFORMATION PROVIDED IN THE APPLICATION. UNDER NO CIRCUMSTANCES SHOULD YOU ALTER YOUR EXISTING
+            MEDICAL TREATMENT, MEDICATION REGIMEN, OR ANY OTHER RELATED HEALTHCARE ACTIVITIES BASED ON ANY INFORMATION
+            PROVIDED IN THE APPLICATION. IT IS IMPORTANT FOR YOU TO DISCUSS YOUR TREATMENT OPTIONS, AND ANY QUESTIONS
+            THAT YOU MAY HAVE, WITH YOUR DOCTOR OR OTHER QUALIFIED HEALTHCARE PROVIDER.</strong></p>
+    <p><strong>8.3 </strong>In making the Application available for download,
+            PCI&rsquo;s goal is to provide individuals with a useful tool for contact tracing. &nbsp;However, the
+            utility of the Application&rsquo;s features is dependent upon a number of factors that are outside the
+            control of PCI, such as the reliability of GPS sensors, whether individuals are carrying their mobile
+            devices, as well as the accuracy, reliability, availability, effectiveness or correct use of
+            individual&rsquo;s mobile devices and GPS sensors, all of which are used to create Location History, and for
+            any Publicly Available Safe Places Data that you may upload into your Application from third party source,
+            the accuracy and completeness of such data. &nbsp;Your Location History or other data may be unavailable,
+            inaccurate or incomplete. &nbsp;Use of the Application should not replace your good judgment and common
+            sense. &nbsp;</strong></p>
+    <p><strong>8.4 </strong><strong>No Liability for Conduct of Third Parties.</strong><span
+            class="c1">&nbsp; YOU ACKNOWLEDGE AND AGREE THAT PCI PARTIES ARE NOT LIABLE, AND YOU AGREE NOT TO SEEK TO
+            HOLD PCI PARTIES LIABLE, FOR THE CONDUCT OR OMISSIONS OF THIRD PARTIES, INCLUDING THE ACTIONS OF ANY THIRD
+            PARTY OPERATING A THIRD PARTY SAFE PLACES WEB APP OR ANY GOVERNMENTAL AGENCY WITH WHICH YOU CHOOSE TO
+            INTERACT IN CONNECTION WITH YOUR USE OF THE APPLICATION, AND THAT THE RISK OF INJURY FROM SUCH THIRD PARTIES
+            RESTS ENTIRELY WITH YOU.</strong></p>
+    <p><strong>9. </strong><strong>LIMITATION OF LIABILITY.</strong></p>
+    <p><strong>9.1 </strong><strong>Disclaimer of Certain Damages.</strong><span
+            class="c1">&nbsp; YOU UNDERSTAND AND AGREE THAT IN NO EVENT SHALL THE PCI PARTIES BE LIABLE FOR ANY LOSS OF
+            PROFITS, PERSONAL INJURY, PROPERTY DAMAGE, WRONGFUL DEATH, REVENUE OR DATA, INDIRECT, INCIDENTAL, SPECIAL,
+            OR CONSEQUENTIAL DAMAGES, OR DAMAGES OR COSTS DUE TO LOSS OF PRODUCTION OR USE, BUSINESS INTERRUPTION,
+            PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, IN EACH CASE WHETHER OR NOT PCI HAS BEEN ADVISED OF THE
+            POSSIBILITY OF SUCH DAMAGES, ARISING OUT OF OR IN CONNECTION WITH THIS AGREEMENT, ON ANY THEORY OF
+            LIABILITY, RESULTING FROM: (1) THE USE OR INABILITY TO USE THE APPLICATION OR ANY OF ITS ADVERTISED
+            FEATURES; (2) &nbsp;UNAUTHORIZED ACCESS TO OR ALTERATION OF YOUR TRANSMISSIONS OR DATA; OR (3) ANY OTHER
+            MATTER RELATED TO THE APPLICATION, WHETHER BASED ON WARRANTY, COPYRIGHT, CONTRACT, TORT (INCLUDING
+            NEGLIGENCE), OR ANY OTHER LEGAL THEORY. &nbsp;THE FOREGOING CAP ON LIABILITY SHALL NOT APPLY TO LIABILITY OF
+            A PCI PARTY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY A PCI PARTY&rsquo;S NEGLIGENCE; OR FOR (B) ANY INJURY
+            CAUSED BY A PCI PARTY&rsquo;S FRAUD OR FRAUDULENT MISREPRESENTATION. </strong></p>
+    <p><strong>9.2 </strong><strong>Cap on Liability.</strong>&nbsp; TO THE
+            MAXIMUM EXTENT PERMITTED BY LAW, NOTWITHSTANDING ANYTHING TO THE CONTRARY CONTAINED HEREIN, OUR LIABILITY TO
+            YOU FOR ANY DAMAGES ARISING FROM OR RELATED TO THESE TERMS OF USE (FOR ANY CAUSE WHATSOEVER AND REGARDLESS
+            OF THE FORM OF THE ACTION), WILL AT ALL TIMES BE LIMITED TO A MAXIMUM OF FIFTY US DOLLARS (U.S. $50). THE
+            EXISTENCE OF MORE THAN ONE CLAIM WILL NOT ENLARGE THIS LIMIT. &nbsp;YOU AGREE THAT OUR SUPPLIERS WILL HAVE
+            NO LIABILITY OF ANY KIND ARISING FROM OR RELATING TO THESE TERMS OF USE.</strong></p>
+    <p><strong>9.3 </strong><strong>Your Data.</strong>&nbsp; EXCEPT FOR
+            PCI&rsquo;S OBLIGATIONS TO PROTECT YOUR PERSONAL DATA AS SET FORTH IN THE PCI&rsquo;S PRIVACY POLICY, PCI
+            ASSUMES NO RESPONSIBILITY FOR THE TIMELINESS, DELETION, MIS-DELIVERY OR FAILURE TO STORE ANY CONTENT
+            (INCLUDING YOUR LOCATION HISTORY), USER COMMUNICATIONS OR PERSONALIZATION SETTINGS.</strong></p>
+    <p><strong>9.4 </strong><strong>Basis of the Bargain.</strong>&nbsp;
+            THE LIMITATIONS OF DAMAGES SET FORTH ABOVE ARE FUNDAMENTAL ELEMENTS OF THE BASIS OF THE BARGAIN BETWEEN PCI
+            AND YOU.</strong></p>
+    <p><strong>10. </strong><strong>REMEDIES.</strong></p>
+    <p><strong>10.1 </strong><strong>Violations.</strong>&nbsp; If PCI
+            becomes aware of any possible violations by you of this Agreement, PCI reserves the right to investigate
+            such violations. &nbsp;If, as a result of the investigation, PCI believes that criminal activity has
+            occurred, PCI reserves the right to refer the matter to, and to cooperate with, any and all applicable legal
+            authorities. &nbsp;PCI is entitled, except to the extent prohibited by applicable law, to disclose any
+            information or materials you provide to PCI in connection with your use of the Application, to (a) comply
+            with applicable laws, legal process or governmental request; (b) enforce these Terms of Use, (c) respond to
+            your requests for customer service, or (d) protect the rights, property or personal safety of PCI or the
+            public, and all enforcement or other government officials, as PCI, in its sole discretion believes to be
+            necessary or appropriate.</strong></p>
+    <p><strong>11. </strong><strong>TERM AND TERMINATION. &nbsp;</strong></p>
+    <p><strong>11.1 </strong><strong>Term.</strong>&nbsp; This Agreement
+            commences on the date when you accept them (as described in the preamble above) and remain in full force and
+            effect while you use the Application, unless terminated earlier in accordance with this Agreement.</strong>
+    </p>
+    <p><strong>11.2 </strong><strong>Prior Use. </strong><span
+            class="c1">&nbsp;Notwithstanding the foregoing, you hereby acknowledge and agree that this Agreement
+            commenced on the earlier to occur of (a) the date you first used the Application or (b) the date you
+            accepted this Agreement and will remain in full force and effect while you use the Application, unless
+            earlier terminated in accordance with this Agreement.</strong></p>
+    <p><strong>11.3 </strong><strong>Termination by You. &nbsp;</strong>If
+            you want to terminate this Agreement, you may do so by deleting the Application from your mobile device.
+            &nbsp;</strong></p>
+    <p><strong>11.4 </strong><strong>Effect of Termination.</strong>&nbsp;
+            Termination of this Agreement requires you to delete the Application and cease all use of it. &nbsp;All
+            provisions of this Agreement which by their nature should survive, shall survive termination, including
+            without limitation, ownership provisions, warranty disclaimers, and limitation of liability.</strong></p>
+    <p><strong>12. </strong><strong>INTERNATIONAL USERS. &nbsp;</strong>The
+            Application is intended solely for use in the United States of America. &nbsp;PCI makes no representations
+            that the Application is functional in other locations. &nbsp;Those who access or use the Application from
+            other countries do so at their own risk and are responsible for use in compliance with local law.</strong></p>
+    <p id="h.30j0zll"><span class="c9 c0">13. </strong><span class="c0 c6">DISPUTE RESOLUTION</strong><span
+            class="c0 c2">.</strong><span class="c2 c13">&nbsp; </strong><span class="c2 c0">Please read the following
+            arbitration agreement in this Section (&ldquo;</strong><span class="c6 c0">Arbitration Agreement</strong><span
+            class="c2 c0">&rdquo;) carefully.&nbsp; It requires U.S. users to arbitrate disputes with PCI and limits the
+            manner in which you can seek relief from us. &nbsp;</strong></p>
+    <p id="h.1fob9te"><strong>13.1 </strong><span class="c0 c3">Applicability of Arbitration
+            Agreement</strong><span class="c17 c13">.</strong>&nbsp;You agree that any dispute, claim, or
+            request for relief relating in any way to your access or use of the Application or to any aspect of your
+            relationship with PCI, will be resolved by binding arbitration, rather than in court, except that (1) you
+            may assert claims or seek relief in small claims court if your claims qualify,; and (2) you or PCI may seek
+            equitable relief in court for infringement or other misuse of intellectual property rights (such as
+            trademarks, trade dress, domain names, trade secrets, copyrights, and patents). &nbsp;</strong><span
+            class="c3 c0">This Arbitration Agreement shall apply, without limitation, to all disputes or claims and
+            requests for relief that arose or were asserted before the effective date of this Agreement or any prior
+            version of this Agreement. </strong>&nbsp;</strong></p>
+    <p><strong>13.2 </strong><strong>Arbitration Rules and Forum</strong><span
+            class="c13 c17">. </strong>&nbsp;The Federal Arbitration Act governs the interpretation and
+            enforcement of this Arbitration Agreement. &nbsp;To begin an arbitration proceeding, you must send a letter
+            requesting arbitration and describing your dispute or claim or request for relief to our registered
+            agent</strong><span class="c1 c12">&nbsp;</strong>Samuel Hoff c/o Pierce &amp; Mandell, P.C. 11
+            Beacon Street Suite 800, Boston MA 02108. &nbsp;The arbitration will be conducted by JAMS, an established
+            alternative dispute resolution provider.&nbsp;&nbsp;Disputes involving claims, counterclaims, or request for
+            relief under $250,000, not inclusive of attorneys&rsquo; fees and interest, shall be subject to JAMS&rsquo;s
+            most current version of the Streamlined Arbitration Rules and procedures available at
+            http://www.jamsadr.com/rules-streamlined-arbitration/; all other disputes shall be subject to JAMS&rsquo;s
+            most current version of the Comprehensive Arbitration Rules and Procedures, available at
+            http://www.jamsadr.com/rules-comprehensive-arbitration/. &nbsp;JAMS&rsquo;s rules are also available at
+            www.jamsadr.com or by calling JAMS at 800-352-5267. &nbsp;If JAMS is not available to arbitrate, the parties
+            will select an alternative arbitral forum. &nbsp;If the arbitrator finds that you cannot afford to pay
+            JAMS&rsquo;s filing, administrative, hearing and/or other fees and cannot obtain a waiver from JAMS, PCI
+            will pay them for you. &nbsp;In addition, PCI will reimburse all such JAMS&rsquo;s filing, administrative,
+            hearing and/or other fees for disputes, claims, or requests for relief totaling less than $10,000 unless the
+            arbitrator determines the claims are frivolous. &nbsp;</strong></p>
+    <p>You may choose to have the arbitration conducted by telephone, based on written
+            submissions, or at another mutually agreed location. &nbsp;Any judgment on the award rendered by the
+            arbitrator may be entered in any court of competent jurisdiction. </strong></p>
+    <p><strong>13.3 </strong><strong>Authority of Arbitrator</strong><span
+            class="c1">.&nbsp; The arbitrator shall have exclusive authority to (a) determine the scope and
+            enforceability of this Arbitration Agreement and (b) resolve any dispute related to the interpretation,
+            applicability, enforceability or formation of this Arbitration Agreement including, but not limited to, any
+            assertion that all or any part of this Arbitration Agreement is void or voidable. &nbsp;The arbitration will
+            decide the rights and liabilities, if any, of you and PCI. &nbsp;The arbitration proceeding will not be
+            consolidated with any other matters or joined with any other cases or parties.&nbsp; The arbitrator shall
+            have the authority to grant motions dispositive of all or part of any claim. The arbitrator shall have the
+            authority to award monetary damages and to grant any non-monetary remedy or relief available to an
+            individual under applicable law, the arbitral forum&rsquo;s rules, and this Agreement (including the
+            Arbitration Agreement). The arbitrator shall issue a written award and statement of decision describing the
+            essential findings and conclusions on which the award is based, including the calculation of any damages
+            awarded.&nbsp; The arbitrator has the same authority to award relief on an individual basis that a judge in
+            a court of law would have.&nbsp; The award of the arbitrator is final and binding upon you and us.&nbsp;
+        </strong></p>
+    <p><span class="c0 c9">13.4 </strong><span class="c6 c0">Waiver of Jury Trial</strong><span
+            class="c4">.&nbsp; YOU AND PCI HEREBY WAIVE ANY CONSTITUTIONAL AND STATUTORY RIGHTS TO SUE IN COURT AND HAVE
+            A TRIAL IN FRONT OF A JUDGE OR A JURY. &nbsp;You and PCI are instead electing that all disputes, claims, or
+            requests for relief shall be resolved by arbitration under this Arbitration Agreement, except as specified
+            in Section 13.1 above.&nbsp; An arbitrator can award on an individual basis the same damages and relief as a
+            court and must follow this Agreement as a court would. &nbsp;However, there is no judge or jury in
+            arbitration, and court review of an arbitration award is subject to very limited review. &nbsp;</strong></p>
+    <p id="h.3znysh7"><span class="c9 c0">13.5 </strong><span class="c6 c0">Waiver of Class or Other
+            Non-Individualized Relief</strong><span class="c4">.&nbsp; ALL DISPUTES, CLAIMS, AND REQUESTS FOR RELIEF
+            WITHIN THE SCOPE OF THIS ARBITRATION AGREEMENT MUST BE ARBITRATED ON AN INDIVIDUAL BASIS AND NOT ON A CLASS
+            OR COLLECTIVE BASIS, ONLY INDIVIDUAL RELIEF IS AVAILABLE, AND CLAIMS OF MORE THAN ONE CUSTOMER OR USER
+            CANNOT BE ARBITRATED OR CONSOLIDATED WITH THOSE OF ANY OTHER CUSTOMER OR USER. &nbsp;If a decision is issued
+            stating that applicable law precludes enforcement of any of this subsection&rsquo;s limitations as to a
+            given dispute, claim, or request for relief, then such aspect must be severed from the arbitration and
+            brought into the State or Federal Courts located in the Commonwealth of Massachusetts. &nbsp;All other
+            disputes, claims, or requests for relief shall be arbitrated. &nbsp;</strong></p>
+    <p><span class="c9 c0">13.6 </strong><span class="c6 c0">30-Day Right to Opt Out</strong><span class="c4">.
+            You have the right to opt out of the provisions of this Arbitration Agreement by sending written notice of
+            your decision to opt out to: </strong>legal@pathcheck.org</strong><span class="c4">, within 30
+            days after first becoming subject to this Arbitration Agreement. &nbsp;Your notice must include your name
+            and address, your email address, and an unequivocal statement that you want to opt out of this Arbitration
+            Agreement. &nbsp;If you opt out of this Arbitration Agreement, all other parts of this Agreement will
+            continue to apply to you. &nbsp;Opting out of this Arbitration Agreement has no effect on any other
+            arbitration agreements that you may currently have, or may enter in the future, with us.</strong></p>
+    <p><span class="c9 c0">13.7 </strong><span class="c6 c0">Severability</strong><span class="c2 c13">.
+        </strong><span class="c4">Except as provided in subsection 13.5, if any part or parts of this Arbitration
+            Agreement are found under the law to be invalid or unenforceable, then such specific part or parts shall be
+            of no force and effect and shall be severed and the remainder of the Arbitration Agreement shall continue in
+            full force and effect.</strong></p>
+    <p><span class="c9 c0">13.8 </strong><span class="c6 c0">Survival of Agreement</strong><span class="c2 c13">.
+        </strong><span class="c4">This Arbitration Agreement will survive the termination of your relationship with
+            PCI.</strong></p>
+    <p><strong>13.9 </strong><strong>Modification</strong>.</strong><span
+            class="c3 c0">&nbsp; </strong>Notwithstanding any provision in this Agreement to the
+            contrary, we agree that if PCI makes any future material change to this Arbitration Agreement, y</strong><span
+            class="c4">ou may reject that change within thirty (30) days of such change becoming effective by writing
+            PCI at the following address: Path Check, Inc. PO Box 441621, Somerville MA 02144</strong></p>
+    <p><strong>14. </strong><strong>GENERAL PROVISIONS.</strong></p>
+    <p><strong>14.1 </strong><strong>Electronic Communications.</strong><span
+            class="c1">&nbsp; The communications between you and PCI may take place via electronic means, whether you
+            send PCI e-mails, or whether PCI posts notices in the Application or through updates made to the Application
+            in accordance with this Terms of Use or communicates with you via e-mail. &nbsp;For contractual purposes,
+            you (a) consent to receive communications from PCI in an electronic form; and (b) agree that all terms and
+            conditions, agreements, notices, disclosures, and other communications that PCI provides to you
+            electronically satisfy any legal requirement that such communications would satisfy if it were to be in
+            writing. &nbsp;The foregoing does not affect your statutory rights, including but not limited to the
+            Electronic Signatures in Global and National Commerce Act at 15 U.S.C. &sect;7001 et seq.
+            (&ldquo;E-Sign&rdquo;).</strong></p>
+    <p><strong>14.2 </strong><strong>Release.</strong>&nbsp; You hereby
+            release the PCI Parties and their successors from claims, demands, any and all losses, damages, rights, and
+            actions of any kind, including personal injuries, death, and property damage, that is either directly or
+            indirectly related to or arises from any interactions with or conduct of operators of Third Party Safe
+            Places Web Apps, healthcare providers, governmental agencies, of any kind arising in connection with or as a
+            result of this Agreement or your use of the Application. &nbsp;If you are a California resident, you hereby
+            waive California Civil Code Section 1542, which states, &ldquo;A general release does not extend to claims
+            that the creditor or releasing party does not know or suspect to exist in his or her favor at the time of
+            executing the release and that, if known by him or her, would have materially affected his or her settlement
+            with the debtor or released party.&rdquo; &nbsp;The foregoing release does not apply to any claims, demands,
+            or any losses, damages, rights and actions of any kind, including personal injuries, death or property
+            damage for any unconscionable commercial practice by a PCI Party or for such party&rsquo;s fraud, deception,
+            false, promise, misrepresentation or concealment, suppression or omission of any material fact in connection
+            with the Application &nbsp;provided hereunder.</strong></p>
+    <p><strong>14.3 </strong><strong>Assignment.</strong>&nbsp; This
+            Agreement, and your rights and obligations hereunder, may not be assigned, subcontracted, delegated or
+            otherwise transferred by you without PCI&rsquo;s prior written consent, and any attempted assignment,
+            subcontract, delegation, or transfer in violation of the foregoing will be null and void.</strong></p>
+    <p><strong>14.4 </strong><strong>Force Majeure.</strong>&nbsp; PCI
+            shall not be liable for any delay or failure to perform resulting from causes outside its reasonable
+            control, including, but not limited to, acts of God, war, terrorism, riots, embargos, acts of civil or
+            military authorities, fire, floods, accidents, strikes or shortages of transportation facilities, fuel,
+            energy, labor or materials. </strong></p>
+    <p><strong>14.5 </strong><strong>Questions, Complaints, Claims.</strong><span
+            class="c1">&nbsp; If you have any questions, complaints or claims with respect to the Application, please
+            contact us at: support@pathcheck.org.</strong></p>
+    <p><strong>14.6 </strong><strong>Exclusive Venue.</strong>&nbsp; To the
+            extent the parties are permitted under this Agreement to initiate litigation in a court, both you and PCI
+            agree that all claims and disputes arising out of or relating to this Agreement will be litigated
+            exclusively in the state or federal courts located in Boston, Massachusetts.</strong></p>
+    <p><strong>14.7 </strong><strong>Governing Law </strong>THE TERMS AND
+            ANY ACTION RELATED THERETO WILL BE GOVERNED AND INTERPRETED BY AND UNDER THE LAWS OF THE COMMONWEALTH OF
+            MASSACHUSETTS, CONSISTENT WITH THE FEDERAL ARBITRATION ACT, WITHOUT GIVING EFFECT TO ANY PRINCIPLES THAT
+            PROVIDE FOR THE APPLICATION OF THE LAW OF ANOTHER JURISDICTION. &nbsp;THE UNITED NATIONS CONVENTION ON
+            CONTRACTS FOR THE INTERNATIONAL SALE OF GOODS DOES NOT APPLY TO THIS AGREEMENT.</strong></p>
+    <p><strong>14.8 </strong><strong>Choice of Language.</strong>&nbsp; It
+            is the express wish of the parties that this Agreement and all related documents have been drawn up in
+            English. </strong></p>
+    <p><strong>14.9 </strong><strong>Notice.</strong>&nbsp; You may give
+            notice to PCI at the following address:</strong><span class="c4">&nbsp;Path Check, Inc. PO Box 441621,
+            Somerville MA 02144.</strong>&nbsp; Such notice shall be deemed given when received by PCI by
+            letter delivered by nationally recognized overnight delivery service or first class postage prepaid mail at
+            the above address.</strong></p>
+    <p><strong>14.10 </strong><strong>Waiver.</strong>&nbsp; Any waiver or
+            failure to enforce any provision of this Agreement on one occasion will not be deemed a waiver of any other
+            provision or of such provision on any other occasion.</strong></p>
+    <p><strong>14.11 </strong><strong>Severability.</strong>&nbsp; If any
+            portion of this Agreement is held invalid or unenforceable, that portion shall be construed in a manner to
+            reflect, as nearly as possible, the original intention of the parties, and the remaining portions shall
+            remain in full force and effect.</strong></p>
+    <p><strong>14.12 </strong><strong>Export Control.</strong>&nbsp; You
+            may not use, export, import, or transfer the Application except as authorized by U.S. law, the laws of the
+            jurisdiction in which you obtained PCI Properties, and any other applicable laws. &nbsp;In particular, but
+            without limitation, the Application may not be exported or re-exported (a) into any United States embargoed
+            countries, or (b) to anyone on the U.S. Treasury Department&rsquo;s list of Specially Designated Nationals
+            or the U.S. Department of Commerce&rsquo;s Denied Person&rsquo;s List or Entity List. By using the
+            Application, you represent and warrant that (y) you are not located in a country that is subject to a U.S.
+            Government embargo, or that has been designated by the U.S. Government as a &ldquo;terrorist
+            supporting&rdquo; country and (z) you are not listed on any U.S. Government list of prohibited or restricted
+            parties. You also will not use the Application for any purpose prohibited by U.S. law, including the
+            development, design, manufacture or production of missiles, nuclear, chemical or biological weapons.
+            &nbsp;You acknowledge and agree that products, services or technology provided by PCI are subject to the
+            export control laws and regulations of the United States. &nbsp;You shall comply with these laws and
+            regulations and shall not, without prior U.S. government authorization, export, re-export, or transfer PCI
+            products, services or technology, either directly or indirectly, to any country in violation of such laws
+            and regulations.</strong></p>
+    <p><strong>14.13 </strong><strong>Accessing and Downloading the Application from
+            iTunes.</strong>&nbsp; The following applies to any App Store Sourced Application accessed
+            through or downloaded from the Apple App Store: </strong></p>
+    <p><strong>(a) </strong>You acknowledge and agree that (i) this Agreement is
+            concluded between you and PCI only, and not Apple, and (ii) PCI, not Apple, is solely responsible for the
+            App Store Sourced Application and content thereof. Your use of the App Store Sourced Application must comply
+            with the App Store Terms of Service. </strong></p>
+    <p><strong>(b) </strong>You acknowledge that Apple has no obligation whatsoever
+            to furnish any maintenance and support services with respect to the App Store Sourced Application. </strong>
+    </p>
+    <p><strong>(c) </strong>In the event of any failure of the App Store Sourced
+            Application to conform to any applicable warranty, you may notify Apple, and Apple will refund the purchase
+            price for the App Store Sourced Application to you and to the maximum extent permitted by applicable law,
+            Apple will have no other warranty obligation whatsoever with respect to the App Store Sourced Application.
+            As between PCI and Apple, any other claims, losses, liabilities, damages, costs or expenses attributable to
+            any failure to conform to any warranty will be the sole responsibility of PCI. </strong></p>
+    <p><strong>(d) </strong>You and PCI acknowledge that, as between PCI and Apple,
+            Apple is not responsible for addressing any claims you have or any claims of any third party relating to the
+            App Store Sourced Application or your possession and use of the App Store Sourced Application, including,
+            but not limited to: (i) product liability claims; (ii) any claim that the App Store Sourced Application
+            fails to conform to any applicable legal or regulatory requirement; and (iii) claims arising under consumer
+            protection or similar legislation.</strong></p>
+    <p><strong>(e) </strong>You and PCI acknowledge that, in the event of any
+            third-party claim that the App Store Sourced Application or your possession and use of that App Store
+            Sourced Application infringes that third party&rsquo;s intellectual property rights, as between PCI and
+            Apple, PCI, not Apple, will be solely responsible for the investigation, defense, settlement and discharge
+            of any such intellectual property infringement claim to the extent required by this Agreement. </strong></p>
+    <p><strong>(f) </strong>You and PCI acknowledge and agree that Apple, and
+            Apple&rsquo;s subsidiaries, are third-party beneficiaries of this Agreement as related to your license of
+            the App Store Sourced Application, and that, upon your acceptance of the terms and conditions of this
+            Agreement, Apple will have the right (and will be deemed to have accepted the right) to enforce this
+            Agreement as related to your license of the App Store Sourced Application against you as a third-party
+            beneficiary thereof. </strong></p>
+    <p><strong>(g) </strong>Without limiting any other terms of this Agreement, you
+            must comply with all applicable third-party terms of agreement when using the App Store Sourced
+            Application.</strong></p>
+    <p><strong>14.14 </strong><strong>Consumer Complaints.</strong>&nbsp;
+            In accordance with California Civil Code &sect;1789.3, you may report complaints to the Complaint Assistance
+            Unit of the Division of Consumer Services of the California Department of Consumer Affairs by contacting
+            them in writing at 1625 North Market Blvd., Suite N 112, Sacramento, CA 95834, or by telephone at (800)
+            952-5210.</strong></p>
+    <p><strong>14.15 </strong><strong>Entire Agreement.</strong>&nbsp; This
+            Agreement is the final, complete and exclusive agreement of the parties with respect to the subject matter
+            hereof and supersedes and merges all prior discussions between the parties with respect to such subject
+            matter.</strong></p>
+    <div>
+        <p><span>Released 23 April 2020</strong>&nbsp;</strong></p>
+        <p></strong></p>
+    </div>
 </body>
 
 </html>

--- a/app/locales/eula/en_html.js
+++ b/app/locales/eula/en_html.js
@@ -21,17 +21,17 @@ export default `
 <body>
     <p><strong>Terms of Use</strong></p>
     <p><strong>Last Updated Date: April 23, 2020</strong></p>
-    <p>PLEASE READ THIS TERMS OF USE AGREEMENT (THE </strong><strong>&ldquo;TERMS
-            OF USE&rdquo; </strong>OR </strong><strong>&ldquo;AGREEMENT&rdquo;</strong><span
-            class="c1">) CAREFULLY. &nbsp;THE SAFE PATH MOBILE APPLICATION (THE &ldquo;</strong><span
-            class="c3 c0">APPLICATION&rdquo;</strong>), AND THE FEATURES AND INFORMATION IN IT ARE
-            CONTROLLED BY PATH CHECK, INC. (&ldquo;</strong><strong>PCI</strong>&rdquo;).
+    <p>PLEASE READ THIS TERMS OF USE AGREEMENT (THE &ldquo;TERMS
+            OF USE&rdquo; </strong>OR &ldquo;AGREEMENT&rdquo;
+                    ) CAREFULLY. &nbsp;THE SAFE PATH MOBILE APPLICATION (THE &ldquo;APPLICATION&rdquo;
+            </strong>), AND THE FEATURES AND INFORMATION IN IT ARE
+            CONTROLLED BY PATH CHECK, INC. (&ldquo;PCI</strong>&rdquo;).
             &nbsp;THESE TERMS OF USE GOVERN THE USE OF THE APPLICATION AND APPLY TO ALL USERS USING THE APPLICATION IN
             ANY WAY, INCLUDING THE FEATURES THEREIN. BY CLICKING ON THE &ldquo;I ACCEPT&rdquo; BUTTON AND/OR DOWNLOADING
             THE APPLICATION, YOU REPRESENT THAT (1) YOU HAVE READ, UNDERSTAND, AND AGREE TO BE BOUND BY THE TERMS OF
             USE, (2) YOU ARE OF LEGAL AGE TO FORM A BINDING CONTRACT WITH PCI, AND (3) YOU HAVE THE AUTHORITY TO ENTER
-            INTO THE TERMS OF USE. &nbsp;</strong><strong>IF YOU DO NOT AGREE TO BE BOUND BY THE TERMS OF USE,
-            YOU MAY NOT ACCESS OR USE THE APPLICATION</strong>.</strong></p>
+            INTO THE TERMS OF USE. &nbsp;IF YOU DO NOT AGREE TO BE BOUND BY THE TERMS OF USE,
+            YOU MAY NOT ACCESS OR USE THE APPLICATION.</p>
     <p><strong>PLEASE BE AWARE THAT SECTION 13 OF THIS AGREEMENT, BELOW, CONTAINS PROVISIONS
             GOVERNING HOW DISPUTES THAT YOU AND WE HAVE AGAINST EACH OTHER ARE RESOLVED, INCLUDING, WITHOUT LIMITATION,
             ANY DISPUTES THAT AROSE OR WERE ASSERTED PRIOR TO THE EFFECTIVE DATE OF THIS AGREEMENT. IN PARTICULAR, IT
@@ -46,43 +46,43 @@ export default `
             CONSISTENT WITH THE FEDERAL ARBITRATION ACT, WITHOUT GIVING EFFECT TO ANY PRINCIPLES THAT PROVIDE FOR THE
             APPLICATION OF THE LAW OF ANY OTHER JURISDICTION. &nbsp;THE UNITED NATIONS CONVENTION ON CONTRACTS FOR THE
             INTERNATIONAL SALE OF GOODS IS EXPRESSLY EXCLUDED FROM THIS AGREEMENT. </strong></p>
-    <p>PLEASE NOTE THAT </strong>THIS AGREEMENT IS SUBJECT TO CHANGE BY PCI
+    <p>PLEASE NOTE THAT <strong>THIS AGREEMENT IS SUBJECT TO CHANGE BY PCI
             IN ITS SOLE DISCRETION AT ANY TIME</strong>. &nbsp;When changes are made, PCI will make a new
             copy of the Terms of Use available within the Application. &nbsp;We will also update the &ldquo;Last
             Updated&rdquo; date at the top of the Terms of Use. &nbsp;Your continued use of the Application after a
             change to the Terms of Use is made constitutes acceptance. &nbsp;PLEASE REGULARLY CHECK THE APPLICATION TO
-            VIEW THE MOST CURRENT TERMS.</strong></p>
-    <p><strong>1. </strong><strong>USE OF THE APPLICATION.</strong>&nbsp;
+            VIEW THE MOST CURRENT TERMS.</p>
+    <p><strong>1. USE OF THE APPLICATION.</strong>&nbsp;
         </strong></p>
-    <p><strong>1.1 </strong><strong>Definitions</strong>. &nbsp;As used in
-            these Terms of Use, the following definitions apply:</strong></p>
-    <p>&ldquo;</strong><strong>App User</strong>&rdquo; means an
-            individual natural person who has downloaded the Application under these Terms of Use.</strong></p>
-    <p>&ldquo;</strong><strong>Location History</strong>&rdquo;
+    <p><strong>1.1 Definitions</strong>. &nbsp;As used in
+            these Terms of Use, the following definitions apply:</p>
+    <p><strong>&ldquo;App User</strong>&rdquo; means an
+            individual natural person who has downloaded the Application under these Terms of Use.</p>
+    <p><strong>&ldquo;Location History</strong>&rdquo;
             means location data collected from an App User&rsquo;s mobile device leveraging GPS, Bluetooth and/or other
             features or software, that the App User elects to have recorded and stored within the Application installed
-            on the App User&rsquo;s mobile device.</strong></p>
-    <p>&ldquo;</strong><strong>Publicly Available Safe Places Data</strong><span
-            class="c1">&rdquo; means anonymized maps of public places where individuals diagnosed with Covid-19 have
+            on the App User&rsquo;s mobile device.</p>
+    <p><strong>&ldquo;Publicly Available Safe Places Data</strong>
+            &rdquo; means anonymized maps of public places where individuals diagnosed with Covid-19 have
             visited and data files of times they visited such places, as compiled and created by a third party, and made
-            available via such third party&rsquo;s Third Party Safe Places Web App.</strong></p>
-    <p>&ldquo;</strong><strong>Safe Places Software</strong>&rdquo;
+            available via such third party&rsquo;s Third Party Safe Places Web App.</p>
+    <p><strong>&ldquo;Safe Places Software</strong>&rdquo;
             means open-source software, available at </strong><span class="c8"><a class="c11"
-                href="https://www.google.com/url?q=https://github.com/tripleblindmarket/safe-places&amp;sa=D&amp;ust=1587722145899000">https://github.com/tripleblindmarket/safe-places</a></strong><span
-            class="c1">, that facilitates contact tracing and related tasks, and is designed for use by third parties,
-            such as government agencies. </strong></p>
-    <p>&ldquo;</strong><strong>Third Party Safe Places Web App</strong><span
-            class="c1">&rdquo; means a web-based application owned and operated by a third party, such as a government
+                href="https://www.google.com/url?q=https://github.com/tripleblindmarket/safe-places&amp;sa=D&amp;ust=1587722145899000">https://github.com/tripleblindmarket/safe-places</a></strong>
+                        , that facilitates contact tracing and related tasks, and is designed for use by third parties,
+            such as government agencies. </span></p>
+    <p><strong>&ldquo;Third Party Safe Places Web App</strong>
+            &rdquo; means a web-based application owned and operated by a third party, such as a government
             agency, that employs Safe Places Software to, among other things, publish Publicly Available Safe Places
-            Data.</strong></p>
-    <p><strong>1.2 </strong><strong>Application Features and Functionality.</strong><span
-            class="c1">&nbsp; The Application is designed to enable App Users, </strong><span class="c13 c16">at their
-            option</strong>: (a) to record their Location History and to store such data locally in the
+            Data.</p>
+    <p><strong>1.2 Application Features and Functionality.</strong>
+            &nbsp; The Application is designed to enable App Users, </strong><span class="c13 c16">at their
+            option</span>: (a) to record their Location History and to store such data locally in the
             Application downloaded to their mobile device, (b) to access Publicly Available Safe Places Data from one or
             more Third Party Safe Places Web Apps and download it to the Safe Paths App downloaded on their mobile
-            device, and (c) to share their stored Location History with third parties that they choose. &nbsp;</strong>
+            device, and (c) to share their stored Location History with third parties that they choose. &nbsp;
     </p>
-    <p><strong>1.3 </strong><strong>Application License. </strong>The
+    <p><strong>1.3 Application License. </strong>The
             Application and the information and content available therein are protected by copyright laws throughout the
             world. &nbsp;Subject to your compliance with this Agreement, PCI grants you a limited non-exclusive,
             non-transferable, non-sublicensable, revocable license to download, install and use a copy of the
@@ -93,22 +93,22 @@ export default `
             will apply in lieu of the terms of this Section 1.3, solely with respect to those components or libraries
             that are licensed under such open source licenses. &nbsp;For a copy of such open source licenses, visit
         </strong><span class="c8"><a class="c11"
-                href="https://www.google.com/url?q=https://github.com/tripleblindmarket/covid-safe-paths/blob/develop/LICENSE&amp;sa=D&amp;ust=1587722145900000">https://github.com/tripleblindmarket/covid-safe-paths/blob/develop/LICENSE</a></strong><span
-            class="c1">. &nbsp;Furthermore, with respect to any Application accessed through or downloaded from the
-            Apple App Store (an</strong><strong>&nbsp;&ldquo;App Store Sourced Application&rdquo;</strong><span
-            class="c1">), you will only use the App Store Sourced Application (a) on an Apple-branded product that runs
+                href="https://www.google.com/url?q=https://github.com/tripleblindmarket/covid-safe-paths/blob/develop/LICENSE&amp;sa=D&amp;ust=1587722145900000">https://github.com/tripleblindmarket/covid-safe-paths/blob/develop/LICENSE</a></strong>
+                        . &nbsp;Furthermore, with respect to any Application accessed through or downloaded from the
+            Apple App Store (an&nbsp;&ldquo;App Store Sourced Application&rdquo;</strong>
+                      ), you will only use the App Store Sourced Application (a) on an Apple-branded product that runs
             the iOS (Apple&rsquo;s proprietary operating system) and (b) as permitted by the &ldquo;Usage Rules&rdquo;
             set forth in the Apple App Store Terms of Service. Notwithstanding the first sentence in this section, with
-            respect to any Application accessed through or downloaded from the Google Play store (a &ldquo;</strong><span
-            class="c3 c0">Google Play Sourced Application</strong>&rdquo;), you may have additional
+            respect to any Application accessed through or downloaded from the Google Play store (a &ldquo;
+            Google Play Sourced Application</strong>&rdquo;), you may have additional
             license rights with respect to use of the Application on a shared basis within your designated family
-            group.</strong></p>
-    <p id="h.gjdgxs"><strong>1.4 </strong><strong>Updates.</strong>&nbsp;
+            group.</p>
+    <p id="h.gjdgxs"><strong>1.4 Updates.</strong>&nbsp;
             You understand that to keep the Application most useful for App Users and to accommodate bug fixes and other
             technological changes, PCI may make updates to the Application after you download the Application.
             &nbsp;These updates will be made available to App Users from the third party from whom you received the
-            Application license, e.g., the Apple App Store or Google Play (each, an </strong><span
-            class="c3 c0">&ldquo;App Store&rdquo;</strong>). &nbsp;You will have the ability, at your
+            Application license, e.g., the Apple App Store or Google Play (each, an &ldquo;App Store
+            &rdquo;</strong>). &nbsp;You will have the ability, at your
             option, to download any updates to the Application that we make freely available through such channels.
             &nbsp;We do not require you to install any updates in order for you to continue using the Application after
             we make such updates available. &nbsp;This is because we do not retain any information about you when you
@@ -120,31 +120,31 @@ export default `
             use the Application. &nbsp;Any updates issued by PCI and installed by you shall be deemed the Application
             and shall be governed by this Safe Places EULA or any subsequent end user license agreement accompanying the
             update.</strong></p>
-    <p><strong>1.5 </strong><strong>Necessary Equipment and Software.</strong><span
-            class="c1">&nbsp; You must provide all equipment and software necessary to download and use the Application
+    <p><strong>1.5 Necessary Equipment and Software.</strong>
+            &nbsp; You must provide all equipment and software necessary to download and use the Application
             and to connect to any third party services or sites, including but not limited to, a mobile device that is
             suitable to connect with and use the Application. &nbsp;You are solely responsible for any fees, including
-            Internet connection or mobile fees, that you incur when accessing the Application. &nbsp;</strong></p>
-    <p><strong>1.6 </strong><strong>Responsibility for Location History and Other Data
+            Internet connection or mobile fees, that you incur when accessing the Application. &nbsp;</p>
+    <p><strong>1.6 Responsibility for Location History and Other Data
             Collected and Stored by You. </strong>&nbsp;PCI has no access to the Location History or any
             other data you collect, receive and store in the installed Application or otherwise on your mobile device.
             &nbsp;Therefore, PCI has no responsibility or liability for the deletion or accuracy of the Location History
             or other data you collect, receive or store in the Application or the failure to store, transmit or receive
             transmission of Location History or other data; or the security, privacy, storage, or transmission of other
-            communications originating with or involving use of the Application. &nbsp;</strong></p>
-    <p><strong>2. </strong><strong>OWNERSHIP.</strong></p>
-    <p><strong>2.1 </strong><strong>Application.</strong>&nbsp; Except with
+            communications originating with or involving use of the Application. &nbsp;</p>
+    <p><strong>2. OWNERSHIP.</strong></p>
+    <p><strong>2.1 Application.</strong>&nbsp; Except with
             respect to your Location History and other data you may collect, retrieve from third parties and store in
             the Application on your device, you agree that PCI and its suppliers own all rights, title and interest in
             and to the Application. &nbsp;You will not remove, alter or obscure any copyright, trademark, service mark
-            or other proprietary rights notices incorporated in or accompanying the Application.</strong></p>
-    <p><strong>2.2 </strong><strong>Trademarks.</strong>&nbsp;COVID Safe
+            or other proprietary rights notices incorporated in or accompanying the Application.</p>
+    <p><strong>2.2 Trademarks.</strong>&nbsp;COVID Safe
             Paths and all related graphics, logos, service marks and trade names used on or in connection with the
             Application or in connection therewith are the trademarks of PCI and may not be used without permission in
             connection with your, or any third-party, products or services. &nbsp;Other trademarks, service marks and
-            trade names that may appear on or in the Application are the property of their respective owners.</strong></p>
-    <p><strong>3. </strong><strong>COLLECTION AND USE OF YOUR PERSONAL
-            INFORMATION.</strong><strong>&nbsp; </strong>You acknowledge that the Application
+            trade names that may appear on or in the Application are the property of their respective owners.</p>
+    <p><strong>3. COLLECTION AND USE OF YOUR PERSONAL
+            INFORMATION.&nbsp; </strong>You acknowledge that the Application
             may collect personal information about you (through your choice to store information in the Application or
             through automatic technology tools), including your Location History. &nbsp;You acknowledge that the
             Application may provide you with opportunities to share personal information about yourself, including your
@@ -157,10 +157,10 @@ export default `
             individuals or entities. &nbsp;We recommend that you make your choices regarding sharing your personal
             information, through the Application or otherwise, carefully. &nbsp;We will have no liability for any
             consequences that may result because you have released or shared information, through the Application or
-            otherwise, with a third party. &nbsp;</strong></p>
-    <p><strong>4. </strong><strong>FEEDBACK</strong>. &nbsp;If you provide
-            PCI with any ideas, suggestions, documents, and/or proposals (</strong><span
-            class="c3 c0">&ldquo;Feedback&rdquo;</strong>) via email or another means, you do so at your
+            otherwise, with a third party. &nbsp;</p>
+    <p><strong>4. FEEDBACK</strong>. &nbsp;If you provide
+            PCI with any ideas, suggestions, documents, and/or proposals (&ldquo;Feedback&rdquo;
+            </strong>) via email or another means, you do so at your
             own risk and you acknowledge and agree that PCI has no obligations (including without limitation obligations
             of confidentiality) with respect to such Feedback. &nbsp;You represent and warrant that you have all rights
             necessary to submit the Feedback. &nbsp;You hereby grant to PCI a fully paid, royalty-free, perpetual,
@@ -168,8 +168,8 @@ export default `
             display, distribute, adapt, modify, re-format, create derivative works of, and otherwise commercially or
             non-commercially exploit in any manner, any and all Feedback, and to sublicense the foregoing rights, in
             connection with the operation and maintenance of the Application, any other PCI products or services, or
-            PCI&rsquo;s &nbsp;business.</strong></p>
-    <p><strong>5. </strong><strong>APP STORES</strong><strong>.
+            PCI&rsquo;s &nbsp;business.</p>
+    <p><strong>5. APP STORES.
             &nbsp;</strong>You acknowledge and agree that the availability of the Application is
             dependent on the App Store from whom you received the Application license. &nbsp;You acknowledge that this
             Agreement is between you and PCI and not with the App Store. &nbsp;PCI, not the App Store, is solely
@@ -181,17 +181,17 @@ export default `
             &nbsp;You agree to comply with, and your license to use the Application is conditioned upon your compliance
             with all terms of agreement imposed by the applicable App Store when using the Application. You acknowledge
             that the App Store (and its subsidiaries) are third-party beneficiaries of this Agreement and will have the
-            right to enforce it.</strong></p>
-    <p><strong>6. </strong><strong>FEES. &nbsp;</strong>No fees shall be
+            right to enforce it.</p>
+    <p><strong>6. FEES. &nbsp;</strong>No fees shall be
             payable under this Agreement for the rights granted under this Agreement. You acknowledge and agree that
             this fee arrangement is made in consideration for the mutual covenants set forth in this Agreement,
             including your obligations hereunder, and the disclaimers, exclusions, and limitations of liability set
-            forth herein.</strong></p>
-    <p><strong>7. </strong><strong>INDEMNIFICATION. &nbsp;</strong>You
+            forth herein.</p>
+    <p><strong>7. INDEMNIFICATION. &nbsp;</strong>You
             agree to indemnify and hold PCI, its parents, subsidiaries, affiliates, officers, employees, volunteers,
-            agents, partners, suppliers, and licensors (each, a &ldquo;</strong><strong>PCI Party</strong><span
-            class="c1">&rdquo; and collectively, the </strong><strong>&ldquo;PCI Parties&rdquo;</strong><span
-            class="c1">) harmless from any losses, costs, liabilities and expenses (including reasonable
+            agents, partners, suppliers, and licensors (each, a &ldquo;PCI Party
+                      &rdquo; and collectively, the &ldquo;PCI Parties&rdquo;
+                      ) harmless from any losses, costs, liabilities and expenses (including reasonable
             attorneys&rsquo; fees) relating to or arising out of any and all of the following: (a) your use of, or
             inability to use the Application; (b) your violation of this Agreement; (c) your violation of any rights of
             another party; or (d) your violation of any applicable laws, rules or regulations. &nbsp;PCI reserves the
@@ -201,36 +201,36 @@ export default `
             unconscionable commercial practice by such party or for such party&rsquo;s fraud, deception, false promise,
             misrepresentation or concealment, suppression or omission of any material fact in connection with the
             Application provided hereunder. You agree that the provisions in this section will survive any termination
-            of this Agreement and/or your use of or access to Application.</strong></p>
-    <p><strong>8. </strong><strong>DISCLAIMER OF WARRANTIES AND CONDITIONS.</strong></p>
-    <p><strong>8.1 </strong><strong>As Is.</strong>&nbsp;YOU EXPRESSLY
+            of this Agreement and/or your use of or access to Application.</p>
+    <p><strong>8. DISCLAIMER OF WARRANTIES AND CONDITIONS.</strong></p>
+    <p><strong>8.1 As Is.</strong>&nbsp;YOU EXPRESSLY
             UNDERSTAND AND AGREE THAT TO THE EXTENT PERMITTED BY APPLICABLE LAW, YOUR USE OF THE APPLICATION IS AT YOUR
             SOLE RISK, AND THE APPLICATION IS PROVIDED ON AN &ldquo;AS IS&rdquo; AND &ldquo;AS AVAILABLE&rdquo; BASIS,
             WITH ALL FAULTS. &nbsp;THE PCI PARTIES EXPRESSLY DISCLAIM ALL WARRANTIES, REPRESENTATIONS, AND CONDITIONS OF
             ANY KIND, WHETHER EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OR CONDITIONS OF
             MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARISING FROM USE OF THE APPLICATION.
-            &nbsp;</strong></p>
+            &nbsp;</p>
     <p><strong>(a) </strong>THE PCI PARTIES MAKE NO WARRANTY, REPRESENTATION OR
             CONDITION THAT: (1) THE APPLICATION OR ITS FEATURES WILL MEET YOUR REQUIREMENTS; (2) YOUR USE OF THE
             APPLICATION WILL BE UNINTERRUPTED, TIMELY, SECURE OR ERROR-FREE; OR (3) THE RESULTS THAT MAY BE OBTAINED
-            FROM USE OF THE APPLICATION WILL BE ACCURATE OR RELIABLE.</strong></p>
+            FROM USE OF THE APPLICATION WILL BE ACCURATE OR RELIABLE.</p>
     <p><strong>(b) </strong>ANY CONTENT DOWNLOADED FROM OR OTHERWISE ACCESSED THROUGH
             THE APPLICATION IS ACCESSED AT YOUR OWN RISK, AND YOU SHALL BE SOLELY RESPONSIBLE FOR ANY DAMAGE TO YOUR
             PROPERTY, INCLUDING, BUT NOT LIMITED TO, YOUR COMPUTER SYSTEM AND ANY DEVICE YOU USE TO ACCESS THE
-            APPLICATION, OR ANY OTHER LOSS THAT RESULTS FROM ACCESSING SUCH CONTENT.</strong></p>
+            APPLICATION, OR ANY OTHER LOSS THAT RESULTS FROM ACCESSING SUCH CONTENT.</p>
     <p><strong>(c) </strong>THE AVAILABILITY OF THE APPLICATION AND ITS FEATURES MAY
             BE SUBJECT TO DELAYS, CANCELLATIONS AND OTHER DISRUPTIONS. &nbsp;PCI MAKES NO WARRANTY, REPRESENTATION OR
             CONDITION WITH RESPECT TO THE APPLICATION OR ITS FEATURES, INCLUDING BUT NOT LIMITED TO, THE QUALITY,
-            EFFECTIVENESS, REPUTATION AND OTHER CHARACTERISTICS THEREOF.</strong></p>
+            EFFECTIVENESS, REPUTATION AND OTHER CHARACTERISTICS THEREOF.</p>
     <p><strong>(d) </strong>NO ADVICE OR INFORMATION, WHETHER ORAL OR WRITTEN,
-            OBTAINED FROM PCI OR THROUGH THE APPLICATION WILL CREATE ANY WARRANTY NOT EXPRESSLY MADE HEREIN.</strong></p>
+            OBTAINED FROM PCI OR THROUGH THE APPLICATION WILL CREATE ANY WARRANTY NOT EXPRESSLY MADE HEREIN.</p>
     <p><strong>(e) </strong>FROM TIME TO TIME, PCI MAY OFFER NEW &ldquo;BETA&rdquo;
             FEATURES OR TOOLS WITH WHICH ITS USERS MAY EXPERIMENT. &nbsp;SUCH FEATURES OR TOOLS ARE OFFERED SOLELY FOR
             EXPERIMENTAL PURPOSES AND WITHOUT ANY WARRANTY OF ANY KIND, AND MAY BE MODIFIED OR DISCONTINUED AT
             PCI&rsquo;S SOLE DISCRETION. &nbsp;THE PROVISIONS OF THIS SECTION APPLY WITH FULL FORCE TO SUCH FEATURES OR
-            TOOLS.</strong></p>
-    <p><strong>8.2 </strong><strong>NOT INTENDED AS MEDICAL ADVICE.</strong><span
-            class="c1">&nbsp;YOU ACKNOWLEDGE THAT THE INFORMATION IN THE APPLICATION IS PROVIDED FOR GENERAL
+            TOOLS.</p>
+    <p><strong>8.2 NOT INTENDED AS MEDICAL ADVICE.</strong>
+            &nbsp;YOU ACKNOWLEDGE THAT THE INFORMATION IN THE APPLICATION IS PROVIDED FOR GENERAL
             INFORMATIONAL PURPOSES ONLY. IT IS NOT INTENDED AS MEDICAL ADVICE OF ANY KIND NOR IS IT INTENDED TO
             DIAGNOSE, TREAT, CURE OR PREVENT ANY DISEASE OR MEDICAL CONDITION. &nbsp;THE INFORMATION PRESENTED IN THE
             APPLICATION SHOULD NOT BE INTERPRETED OR CONSTRUED IN ANY WAY AS A REPLACEMENT OR SUBSTITUTE FOR MEDICAL
@@ -239,7 +239,7 @@ export default `
             TO ANY INFORMATION PROVIDED IN THE APPLICATION. UNDER NO CIRCUMSTANCES SHOULD YOU ALTER YOUR EXISTING
             MEDICAL TREATMENT, MEDICATION REGIMEN, OR ANY OTHER RELATED HEALTHCARE ACTIVITIES BASED ON ANY INFORMATION
             PROVIDED IN THE APPLICATION. IT IS IMPORTANT FOR YOU TO DISCUSS YOUR TREATMENT OPTIONS, AND ANY QUESTIONS
-            THAT YOU MAY HAVE, WITH YOUR DOCTOR OR OTHER QUALIFIED HEALTHCARE PROVIDER.</strong></p>
+            THAT YOU MAY HAVE, WITH YOUR DOCTOR OR OTHER QUALIFIED HEALTHCARE PROVIDER.</p>
     <p><strong>8.3 </strong>In making the Application available for download,
             PCI&rsquo;s goal is to provide individuals with a useful tool for contact tracing. &nbsp;However, the
             utility of the Application&rsquo;s features is dependent upon a number of factors that are outside the
@@ -249,16 +249,16 @@ export default `
             any Publicly Available Safe Places Data that you may upload into your Application from third party source,
             the accuracy and completeness of such data. &nbsp;Your Location History or other data may be unavailable,
             inaccurate or incomplete. &nbsp;Use of the Application should not replace your good judgment and common
-            sense. &nbsp;</strong></p>
-    <p><strong>8.4 </strong><strong>No Liability for Conduct of Third Parties.</strong><span
-            class="c1">&nbsp; YOU ACKNOWLEDGE AND AGREE THAT PCI PARTIES ARE NOT LIABLE, AND YOU AGREE NOT TO SEEK TO
+            sense. &nbsp;</p>
+    <p><strong>8.4 No Liability for Conduct of Third Parties.</strong>
+            &nbsp; YOU ACKNOWLEDGE AND AGREE THAT PCI PARTIES ARE NOT LIABLE, AND YOU AGREE NOT TO SEEK TO
             HOLD PCI PARTIES LIABLE, FOR THE CONDUCT OR OMISSIONS OF THIRD PARTIES, INCLUDING THE ACTIONS OF ANY THIRD
             PARTY OPERATING A THIRD PARTY SAFE PLACES WEB APP OR ANY GOVERNMENTAL AGENCY WITH WHICH YOU CHOOSE TO
             INTERACT IN CONNECTION WITH YOUR USE OF THE APPLICATION, AND THAT THE RISK OF INJURY FROM SUCH THIRD PARTIES
-            RESTS ENTIRELY WITH YOU.</strong></p>
-    <p><strong>9. </strong><strong>LIMITATION OF LIABILITY.</strong></p>
-    <p><strong>9.1 </strong><strong>Disclaimer of Certain Damages.</strong><span
-            class="c1">&nbsp; YOU UNDERSTAND AND AGREE THAT IN NO EVENT SHALL THE PCI PARTIES BE LIABLE FOR ANY LOSS OF
+            RESTS ENTIRELY WITH YOU.</p>
+    <p><strong>9. LIMITATION OF LIABILITY.</strong></p>
+    <p><strong>9.1 Disclaimer of Certain Damages.</strong>
+            &nbsp; YOU UNDERSTAND AND AGREE THAT IN NO EVENT SHALL THE PCI PARTIES BE LIABLE FOR ANY LOSS OF
             PROFITS, PERSONAL INJURY, PROPERTY DAMAGE, WRONGFUL DEATH, REVENUE OR DATA, INDIRECT, INCIDENTAL, SPECIAL,
             OR CONSEQUENTIAL DAMAGES, OR DAMAGES OR COSTS DUE TO LOSS OF PRODUCTION OR USE, BUSINESS INTERRUPTION,
             PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, IN EACH CASE WHETHER OR NOT PCI HAS BEEN ADVISED OF THE
@@ -268,22 +268,22 @@ export default `
             MATTER RELATED TO THE APPLICATION, WHETHER BASED ON WARRANTY, COPYRIGHT, CONTRACT, TORT (INCLUDING
             NEGLIGENCE), OR ANY OTHER LEGAL THEORY. &nbsp;THE FOREGOING CAP ON LIABILITY SHALL NOT APPLY TO LIABILITY OF
             A PCI PARTY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY A PCI PARTY&rsquo;S NEGLIGENCE; OR FOR (B) ANY INJURY
-            CAUSED BY A PCI PARTY&rsquo;S FRAUD OR FRAUDULENT MISREPRESENTATION. </strong></p>
-    <p><strong>9.2 </strong><strong>Cap on Liability.</strong>&nbsp; TO THE
+            CAUSED BY A PCI PARTY&rsquo;S FRAUD OR FRAUDULENT MISREPRESENTATION. </p>
+    <p><strong>9.2 Cap on Liability.</strong>&nbsp; TO THE
             MAXIMUM EXTENT PERMITTED BY LAW, NOTWITHSTANDING ANYTHING TO THE CONTRARY CONTAINED HEREIN, OUR LIABILITY TO
             YOU FOR ANY DAMAGES ARISING FROM OR RELATED TO THESE TERMS OF USE (FOR ANY CAUSE WHATSOEVER AND REGARDLESS
             OF THE FORM OF THE ACTION), WILL AT ALL TIMES BE LIMITED TO A MAXIMUM OF FIFTY US DOLLARS (U.S. $50). THE
             EXISTENCE OF MORE THAN ONE CLAIM WILL NOT ENLARGE THIS LIMIT. &nbsp;YOU AGREE THAT OUR SUPPLIERS WILL HAVE
-            NO LIABILITY OF ANY KIND ARISING FROM OR RELATING TO THESE TERMS OF USE.</strong></p>
-    <p><strong>9.3 </strong><strong>Your Data.</strong>&nbsp; EXCEPT FOR
+            NO LIABILITY OF ANY KIND ARISING FROM OR RELATING TO THESE TERMS OF USE.</p>
+    <p><strong>9.3 Your Data.</strong>&nbsp; EXCEPT FOR
             PCI&rsquo;S OBLIGATIONS TO PROTECT YOUR PERSONAL DATA AS SET FORTH IN THE PCI&rsquo;S PRIVACY POLICY, PCI
             ASSUMES NO RESPONSIBILITY FOR THE TIMELINESS, DELETION, MIS-DELIVERY OR FAILURE TO STORE ANY CONTENT
-            (INCLUDING YOUR LOCATION HISTORY), USER COMMUNICATIONS OR PERSONALIZATION SETTINGS.</strong></p>
-    <p><strong>9.4 </strong><strong>Basis of the Bargain.</strong>&nbsp;
+            (INCLUDING YOUR LOCATION HISTORY), USER COMMUNICATIONS OR PERSONALIZATION SETTINGS.</p>
+    <p><strong>9.4 Basis of the Bargain.</strong>&nbsp;
             THE LIMITATIONS OF DAMAGES SET FORTH ABOVE ARE FUNDAMENTAL ELEMENTS OF THE BASIS OF THE BARGAIN BETWEEN PCI
-            AND YOU.</strong></p>
-    <p><strong>10. </strong><strong>REMEDIES.</strong></p>
-    <p><strong>10.1 </strong><strong>Violations.</strong>&nbsp; If PCI
+            AND YOU.</p>
+    <p><strong>10. REMEDIES.</strong></p>
+    <p><strong>10.1 Violations.</strong>&nbsp; If PCI
             becomes aware of any possible violations by you of this Agreement, PCI reserves the right to investigate
             such violations. &nbsp;If, as a result of the investigation, PCI believes that criminal activity has
             occurred, PCI reserves the right to refer the matter to, and to cooperate with, any and all applicable legal
@@ -292,48 +292,48 @@ export default `
             with applicable laws, legal process or governmental request; (b) enforce these Terms of Use, (c) respond to
             your requests for customer service, or (d) protect the rights, property or personal safety of PCI or the
             public, and all enforcement or other government officials, as PCI, in its sole discretion believes to be
-            necessary or appropriate.</strong></p>
-    <p><strong>11. </strong><strong>TERM AND TERMINATION. &nbsp;</strong></p>
-    <p><strong>11.1 </strong><strong>Term.</strong>&nbsp; This Agreement
+            necessary or appropriate.</p>
+    <p><strong>11. TERM AND TERMINATION. &nbsp;</strong></p>
+    <p><strong>11.1 Term.</strong>&nbsp; This Agreement
             commences on the date when you accept them (as described in the preamble above) and remain in full force and
-            effect while you use the Application, unless terminated earlier in accordance with this Agreement.</strong>
+            effect while you use the Application, unless terminated earlier in accordance with this Agreement.
     </p>
-    <p><strong>11.2 </strong><strong>Prior Use. </strong><span
-            class="c1">&nbsp;Notwithstanding the foregoing, you hereby acknowledge and agree that this Agreement
+    <p><strong>11.2 Prior Use. </strong>
+            &nbsp;Notwithstanding the foregoing, you hereby acknowledge and agree that this Agreement
             commenced on the earlier to occur of (a) the date you first used the Application or (b) the date you
             accepted this Agreement and will remain in full force and effect while you use the Application, unless
-            earlier terminated in accordance with this Agreement.</strong></p>
-    <p><strong>11.3 </strong><strong>Termination by You. &nbsp;</strong>If
+            earlier terminated in accordance with this Agreement.</p>
+    <p><strong>11.3 Termination by You. &nbsp;</strong>If
             you want to terminate this Agreement, you may do so by deleting the Application from your mobile device.
-            &nbsp;</strong></p>
-    <p><strong>11.4 </strong><strong>Effect of Termination.</strong>&nbsp;
+            &nbsp;</p>
+    <p><strong>11.4 Effect of Termination.</strong>&nbsp;
             Termination of this Agreement requires you to delete the Application and cease all use of it. &nbsp;All
             provisions of this Agreement which by their nature should survive, shall survive termination, including
-            without limitation, ownership provisions, warranty disclaimers, and limitation of liability.</strong></p>
-    <p><strong>12. </strong><strong>INTERNATIONAL USERS. &nbsp;</strong>The
+            without limitation, ownership provisions, warranty disclaimers, and limitation of liability.</p>
+    <p><strong>12. INTERNATIONAL USERS. &nbsp;</strong>The
             Application is intended solely for use in the United States of America. &nbsp;PCI makes no representations
             that the Application is functional in other locations. &nbsp;Those who access or use the Application from
             other countries do so at their own risk and are responsible for use in compliance with local law.</strong></p>
-    <p id="h.30j0zll"><span class="c9 c0">13. </strong><span class="c0 c6">DISPUTE RESOLUTION</strong><span
-            class="c0 c2">.</strong><span class="c2 c13">&nbsp; </strong><span class="c2 c0">Please read the following
-            arbitration agreement in this Section (&ldquo;</strong><span class="c6 c0">Arbitration Agreement</strong><span
-            class="c2 c0">&rdquo;) carefully.&nbsp; It requires U.S. users to arbitrate disputes with PCI and limits the
+    <p id="h.30j0zll"><strong>13. DISPUTE RESOLUTION.</strong>
+            &nbsp; <strong>Please read the following
+            arbitration agreement in this Section (&ldquo;Arbitration Agreement
+            &rdquo;) carefully.&nbsp; It requires U.S. users to arbitrate disputes with PCI and limits the
             manner in which you can seek relief from us. &nbsp;</strong></p>
-    <p id="h.1fob9te"><strong>13.1 </strong><span class="c0 c3">Applicability of Arbitration
-            Agreement</strong><span class="c17 c13">.</strong>&nbsp;You agree that any dispute, claim, or
+    <p id="h.1fob9te"><strong>13.1 Applicability of Arbitration
+            Agreement</strong>.&nbsp;You agree that any dispute, claim, or
             request for relief relating in any way to your access or use of the Application or to any aspect of your
             relationship with PCI, will be resolved by binding arbitration, rather than in court, except that (1) you
             may assert claims or seek relief in small claims court if your claims qualify,; and (2) you or PCI may seek
             equitable relief in court for infringement or other misuse of intellectual property rights (such as
-            trademarks, trade dress, domain names, trade secrets, copyrights, and patents). &nbsp;</strong><span
-            class="c3 c0">This Arbitration Agreement shall apply, without limitation, to all disputes or claims and
+            trademarks, trade dress, domain names, trade secrets, copyrights, and patents). &nbsp;<strong>
+            This Arbitration Agreement shall apply, without limitation, to all disputes or claims and
             requests for relief that arose or were asserted before the effective date of this Agreement or any prior
-            version of this Agreement. </strong>&nbsp;</strong></p>
-    <p><strong>13.2 </strong><strong>Arbitration Rules and Forum</strong><span
-            class="c13 c17">. </strong>&nbsp;The Federal Arbitration Act governs the interpretation and
+            version of this Agreement. </strong>&nbsp;</p>
+    <p><strong>13.2 Arbitration Rules and Forum</strong>
+            The Federal Arbitration Act governs the interpretation and
             enforcement of this Arbitration Agreement. &nbsp;To begin an arbitration proceeding, you must send a letter
             requesting arbitration and describing your dispute or claim or request for relief to our registered
-            agent</strong><span class="c1 c12">&nbsp;</strong>Samuel Hoff c/o Pierce &amp; Mandell, P.C. 11
+            agent&nbsp;Samuel Hoff c/o Pierce &amp; Mandell, P.C. 11
             Beacon Street Suite 800, Boston MA 02108. &nbsp;The arbitration will be conducted by JAMS, an established
             alternative dispute resolution provider.&nbsp;&nbsp;Disputes involving claims, counterclaims, or request for
             relief under $250,000, not inclusive of attorneys&rsquo; fees and interest, shall be subject to JAMS&rsquo;s
@@ -346,12 +346,12 @@ export default `
             JAMS&rsquo;s filing, administrative, hearing and/or other fees and cannot obtain a waiver from JAMS, PCI
             will pay them for you. &nbsp;In addition, PCI will reimburse all such JAMS&rsquo;s filing, administrative,
             hearing and/or other fees for disputes, claims, or requests for relief totaling less than $10,000 unless the
-            arbitrator determines the claims are frivolous. &nbsp;</strong></p>
+            arbitrator determines the claims are frivolous. &nbsp;</p>
     <p>You may choose to have the arbitration conducted by telephone, based on written
             submissions, or at another mutually agreed location. &nbsp;Any judgment on the award rendered by the
-            arbitrator may be entered in any court of competent jurisdiction. </strong></p>
-    <p><strong>13.3 </strong><strong>Authority of Arbitrator</strong><span
-            class="c1">.&nbsp; The arbitrator shall have exclusive authority to (a) determine the scope and
+            arbitrator may be entered in any court of competent jurisdiction. </p>
+    <p><strong>13.3 Authority of Arbitrator</strong>
+            .&nbsp; The arbitrator shall have exclusive authority to (a) determine the scope and
             enforceability of this Arbitration Agreement and (b) resolve any dispute related to the interpretation,
             applicability, enforceability or formation of this Arbitration Agreement including, but not limited to, any
             assertion that all or any part of this Arbitration Agreement is void or voidable. &nbsp;The arbitration will
@@ -364,47 +364,47 @@ export default `
             essential findings and conclusions on which the award is based, including the calculation of any damages
             awarded.&nbsp; The arbitrator has the same authority to award relief on an individual basis that a judge in
             a court of law would have.&nbsp; The award of the arbitrator is final and binding upon you and us.&nbsp;
-        </strong></p>
-    <p><span class="c0 c9">13.4 </strong><span class="c6 c0">Waiver of Jury Trial</strong><span
-            class="c4">.&nbsp; YOU AND PCI HEREBY WAIVE ANY CONSTITUTIONAL AND STATUTORY RIGHTS TO SUE IN COURT AND HAVE
+        </p>
+    <p><strong>13.4 Waiver of Jury Trial</strong>
+            .&nbsp; YOU AND PCI HEREBY WAIVE ANY CONSTITUTIONAL AND STATUTORY RIGHTS TO SUE IN COURT AND HAVE
             A TRIAL IN FRONT OF A JUDGE OR A JURY. &nbsp;You and PCI are instead electing that all disputes, claims, or
             requests for relief shall be resolved by arbitration under this Arbitration Agreement, except as specified
             in Section 13.1 above.&nbsp; An arbitrator can award on an individual basis the same damages and relief as a
             court and must follow this Agreement as a court would. &nbsp;However, there is no judge or jury in
-            arbitration, and court review of an arbitration award is subject to very limited review. &nbsp;</strong></p>
-    <p id="h.3znysh7"><span class="c9 c0">13.5 </strong><span class="c6 c0">Waiver of Class or Other
-            Non-Individualized Relief</strong><span class="c4">.&nbsp; ALL DISPUTES, CLAIMS, AND REQUESTS FOR RELIEF
+            arbitration, and court review of an arbitration award is subject to very limited review. &nbsp;</p>
+    <p id="h.3znysh7"><strong>13.5 Waiver of Class or Other
+            Non-Individualized Relief</strong>.&nbsp; ALL DISPUTES, CLAIMS, AND REQUESTS FOR RELIEF
             WITHIN THE SCOPE OF THIS ARBITRATION AGREEMENT MUST BE ARBITRATED ON AN INDIVIDUAL BASIS AND NOT ON A CLASS
             OR COLLECTIVE BASIS, ONLY INDIVIDUAL RELIEF IS AVAILABLE, AND CLAIMS OF MORE THAN ONE CUSTOMER OR USER
             CANNOT BE ARBITRATED OR CONSOLIDATED WITH THOSE OF ANY OTHER CUSTOMER OR USER. &nbsp;If a decision is issued
             stating that applicable law precludes enforcement of any of this subsection&rsquo;s limitations as to a
             given dispute, claim, or request for relief, then such aspect must be severed from the arbitration and
             brought into the State or Federal Courts located in the Commonwealth of Massachusetts. &nbsp;All other
-            disputes, claims, or requests for relief shall be arbitrated. &nbsp;</strong></p>
-    <p><span class="c9 c0">13.6 </strong><span class="c6 c0">30-Day Right to Opt Out</strong><span class="c4">.
+            disputes, claims, or requests for relief shall be arbitrated. &nbsp;</p>
+    <p><strong>13.6 30-Day Right to Opt Out</strong>.
             You have the right to opt out of the provisions of this Arbitration Agreement by sending written notice of
-            your decision to opt out to: </strong>legal@pathcheck.org</strong><span class="c4">, within 30
+            your decision to opt out to: </strong>legal@pathcheck.org</strong>, within 30
             days after first becoming subject to this Arbitration Agreement. &nbsp;Your notice must include your name
             and address, your email address, and an unequivocal statement that you want to opt out of this Arbitration
             Agreement. &nbsp;If you opt out of this Arbitration Agreement, all other parts of this Agreement will
             continue to apply to you. &nbsp;Opting out of this Arbitration Agreement has no effect on any other
-            arbitration agreements that you may currently have, or may enter in the future, with us.</strong></p>
-    <p><span class="c9 c0">13.7 </strong><span class="c6 c0">Severability</strong><span class="c2 c13">.
+            arbitration agreements that you may currently have, or may enter in the future, with us.</p>
+    <p><strong>13.7 Severability. </strong>
         </strong><span class="c4">Except as provided in subsection 13.5, if any part or parts of this Arbitration
             Agreement are found under the law to be invalid or unenforceable, then such specific part or parts shall be
             of no force and effect and shall be severed and the remainder of the Arbitration Agreement shall continue in
-            full force and effect.</strong></p>
-    <p><span class="c9 c0">13.8 </strong><span class="c6 c0">Survival of Agreement</strong><span class="c2 c13">.
+            full force and effect.</p>
+    <p><strong>13.8 Survival of Agreement</strong><span class="c2 c13">.
         </strong><span class="c4">This Arbitration Agreement will survive the termination of your relationship with
-            PCI.</strong></p>
-    <p><strong>13.9 </strong><strong>Modification</strong>.</strong><span
-            class="c3 c0">&nbsp; </strong>Notwithstanding any provision in this Agreement to the
-            contrary, we agree that if PCI makes any future material change to this Arbitration Agreement, y</strong><span
-            class="c4">ou may reject that change within thirty (30) days of such change becoming effective by writing
-            PCI at the following address: Path Check, Inc. PO Box 441621, Somerville MA 02144</strong></p>
-    <p><strong>14. </strong><strong>GENERAL PROVISIONS.</strong></p>
-    <p><strong>14.1 </strong><strong>Electronic Communications.</strong><span
-            class="c1">&nbsp; The communications between you and PCI may take place via electronic means, whether you
+            PCI.</p>
+    <p><strong>13.9 Modification</strong>.
+            Notwithstanding any provision in this Agreement to the
+            contrary, we agree that if PCI makes any future material change to this Arbitration Agreement, you may 
+            reject that change within thirty (30) days of such change becoming effective by writing
+            PCI at the following address: Path Check, Inc. PO Box 441621, Somerville MA 02144</p>
+    <p><strong>14. GENERAL PROVISIONS.</strong></p>
+    <p><strong>14.1 Electronic Communications.</strong>
+            &nbsp; The communications between you and PCI may take place via electronic means, whether you
             send PCI e-mails, or whether PCI posts notices in the Application or through updates made to the Application
             in accordance with this Terms of Use or communicates with you via e-mail. &nbsp;For contractual purposes,
             you (a) consent to receive communications from PCI in an electronic form; and (b) agree that all terms and
@@ -412,8 +412,8 @@ export default `
             electronically satisfy any legal requirement that such communications would satisfy if it were to be in
             writing. &nbsp;The foregoing does not affect your statutory rights, including but not limited to the
             Electronic Signatures in Global and National Commerce Act at 15 U.S.C. &sect;7001 et seq.
-            (&ldquo;E-Sign&rdquo;).</strong></p>
-    <p><strong>14.2 </strong><strong>Release.</strong>&nbsp; You hereby
+            (&ldquo;E-Sign&rdquo;).</p>
+    <p><strong>14.2 Release.</strong>&nbsp; You hereby
             release the PCI Parties and their successors from claims, demands, any and all losses, damages, rights, and
             actions of any kind, including personal injuries, death, and property damage, that is either directly or
             indirectly related to or arises from any interactions with or conduct of operators of Third Party Safe
@@ -426,44 +426,44 @@ export default `
             or any losses, damages, rights and actions of any kind, including personal injuries, death or property
             damage for any unconscionable commercial practice by a PCI Party or for such party&rsquo;s fraud, deception,
             false, promise, misrepresentation or concealment, suppression or omission of any material fact in connection
-            with the Application &nbsp;provided hereunder.</strong></p>
-    <p><strong>14.3 </strong><strong>Assignment.</strong>&nbsp; This
+            with the Application &nbsp;provided hereunder.</p>
+    <p><strong>14.3 Assignment.</strong>&nbsp; This
             Agreement, and your rights and obligations hereunder, may not be assigned, subcontracted, delegated or
             otherwise transferred by you without PCI&rsquo;s prior written consent, and any attempted assignment,
-            subcontract, delegation, or transfer in violation of the foregoing will be null and void.</strong></p>
-    <p><strong>14.4 </strong><strong>Force Majeure.</strong>&nbsp; PCI
+            subcontract, delegation, or transfer in violation of the foregoing will be null and void.</p>
+    <p><strong>14.4 Force Majeure.</strong>&nbsp; PCI
             shall not be liable for any delay or failure to perform resulting from causes outside its reasonable
             control, including, but not limited to, acts of God, war, terrorism, riots, embargos, acts of civil or
             military authorities, fire, floods, accidents, strikes or shortages of transportation facilities, fuel,
-            energy, labor or materials. </strong></p>
-    <p><strong>14.5 </strong><strong>Questions, Complaints, Claims.</strong><span
-            class="c1">&nbsp; If you have any questions, complaints or claims with respect to the Application, please
-            contact us at: support@pathcheck.org.</strong></p>
-    <p><strong>14.6 </strong><strong>Exclusive Venue.</strong>&nbsp; To the
+            energy, labor or materials. </p>
+    <p><strong>14.5 Questions, Complaints, Claims.</strong>
+            &nbsp; If you have any questions, complaints or claims with respect to the Application, please
+            contact us at: support@pathcheck.org.</p>
+    <p><strong>14.6 Exclusive Venue.</strong>&nbsp; To the
             extent the parties are permitted under this Agreement to initiate litigation in a court, both you and PCI
             agree that all claims and disputes arising out of or relating to this Agreement will be litigated
-            exclusively in the state or federal courts located in Boston, Massachusetts.</strong></p>
-    <p><strong>14.7 </strong><strong>Governing Law </strong>THE TERMS AND
+            exclusively in the state or federal courts located in Boston, Massachusetts.</p>
+    <p><strong>14.7 Governing Law </strong>THE TERMS AND
             ANY ACTION RELATED THERETO WILL BE GOVERNED AND INTERPRETED BY AND UNDER THE LAWS OF THE COMMONWEALTH OF
             MASSACHUSETTS, CONSISTENT WITH THE FEDERAL ARBITRATION ACT, WITHOUT GIVING EFFECT TO ANY PRINCIPLES THAT
             PROVIDE FOR THE APPLICATION OF THE LAW OF ANOTHER JURISDICTION. &nbsp;THE UNITED NATIONS CONVENTION ON
-            CONTRACTS FOR THE INTERNATIONAL SALE OF GOODS DOES NOT APPLY TO THIS AGREEMENT.</strong></p>
-    <p><strong>14.8 </strong><strong>Choice of Language.</strong>&nbsp; It
+            CONTRACTS FOR THE INTERNATIONAL SALE OF GOODS DOES NOT APPLY TO THIS AGREEMENT.</p>
+    <p><strong>14.8 Choice of Language.</strong>&nbsp; It
             is the express wish of the parties that this Agreement and all related documents have been drawn up in
-            English. </strong></p>
-    <p><strong>14.9 </strong><strong>Notice.</strong>&nbsp; You may give
-            notice to PCI at the following address:</strong><span class="c4">&nbsp;Path Check, Inc. PO Box 441621,
+            English. </p>
+    <p><strong>14.9 Notice.</strong>&nbsp; You may give
+            notice to PCI at the following address:&nbsp;Path Check, Inc. PO Box 441621,
             Somerville MA 02144.</strong>&nbsp; Such notice shall be deemed given when received by PCI by
             letter delivered by nationally recognized overnight delivery service or first class postage prepaid mail at
-            the above address.</strong></p>
-    <p><strong>14.10 </strong><strong>Waiver.</strong>&nbsp; Any waiver or
+            the above address.</p>
+    <p><strong>14.10 Waiver.</strong>&nbsp; Any waiver or
             failure to enforce any provision of this Agreement on one occasion will not be deemed a waiver of any other
-            provision or of such provision on any other occasion.</strong></p>
-    <p><strong>14.11 </strong><strong>Severability.</strong>&nbsp; If any
+            provision or of such provision on any other occasion.</p>
+    <p><strong>14.11 Severability.</strong>&nbsp; If any
             portion of this Agreement is held invalid or unenforceable, that portion shall be construed in a manner to
             reflect, as nearly as possible, the original intention of the parties, and the remaining portions shall
-            remain in full force and effect.</strong></p>
-    <p><strong>14.12 </strong><strong>Export Control.</strong>&nbsp; You
+            remain in full force and effect.</p>
+    <p><strong>14.12 Export Control.</strong>&nbsp; You
             may not use, export, import, or transfer the Application except as authorized by U.S. law, the laws of the
             jurisdiction in which you obtained PCI Properties, and any other applicable laws. &nbsp;In particular, but
             without limitation, the Application may not be exported or re-exported (a) into any United States embargoed
@@ -478,56 +478,52 @@ export default `
             export control laws and regulations of the United States. &nbsp;You shall comply with these laws and
             regulations and shall not, without prior U.S. government authorization, export, re-export, or transfer PCI
             products, services or technology, either directly or indirectly, to any country in violation of such laws
-            and regulations.</strong></p>
-    <p><strong>14.13 </strong><strong>Accessing and Downloading the Application from
+            and regulations.</p>
+    <p><strong>14.13 Accessing and Downloading the Application from
             iTunes.</strong>&nbsp; The following applies to any App Store Sourced Application accessed
-            through or downloaded from the Apple App Store: </strong></p>
+            through or downloaded from the Apple App Store: </p>
     <p><strong>(a) </strong>You acknowledge and agree that (i) this Agreement is
             concluded between you and PCI only, and not Apple, and (ii) PCI, not Apple, is solely responsible for the
             App Store Sourced Application and content thereof. Your use of the App Store Sourced Application must comply
-            with the App Store Terms of Service. </strong></p>
+            with the App Store Terms of Service. </p>
     <p><strong>(b) </strong>You acknowledge that Apple has no obligation whatsoever
-            to furnish any maintenance and support services with respect to the App Store Sourced Application. </strong>
+            to furnish any maintenance and support services with respect to the App Store Sourced Application.
     </p>
     <p><strong>(c) </strong>In the event of any failure of the App Store Sourced
             Application to conform to any applicable warranty, you may notify Apple, and Apple will refund the purchase
             price for the App Store Sourced Application to you and to the maximum extent permitted by applicable law,
             Apple will have no other warranty obligation whatsoever with respect to the App Store Sourced Application.
             As between PCI and Apple, any other claims, losses, liabilities, damages, costs or expenses attributable to
-            any failure to conform to any warranty will be the sole responsibility of PCI. </strong></p>
+            any failure to conform to any warranty will be the sole responsibility of PCI.</p>
     <p><strong>(d) </strong>You and PCI acknowledge that, as between PCI and Apple,
             Apple is not responsible for addressing any claims you have or any claims of any third party relating to the
             App Store Sourced Application or your possession and use of the App Store Sourced Application, including,
             but not limited to: (i) product liability claims; (ii) any claim that the App Store Sourced Application
             fails to conform to any applicable legal or regulatory requirement; and (iii) claims arising under consumer
-            protection or similar legislation.</strong></p>
+            protection or similar legislation.</p>
     <p><strong>(e) </strong>You and PCI acknowledge that, in the event of any
             third-party claim that the App Store Sourced Application or your possession and use of that App Store
             Sourced Application infringes that third party&rsquo;s intellectual property rights, as between PCI and
             Apple, PCI, not Apple, will be solely responsible for the investigation, defense, settlement and discharge
-            of any such intellectual property infringement claim to the extent required by this Agreement. </strong></p>
+            of any such intellectual property infringement claim to the extent required by this Agreement. </p>
     <p><strong>(f) </strong>You and PCI acknowledge and agree that Apple, and
             Apple&rsquo;s subsidiaries, are third-party beneficiaries of this Agreement as related to your license of
             the App Store Sourced Application, and that, upon your acceptance of the terms and conditions of this
             Agreement, Apple will have the right (and will be deemed to have accepted the right) to enforce this
             Agreement as related to your license of the App Store Sourced Application against you as a third-party
-            beneficiary thereof. </strong></p>
+            beneficiary thereof. </p>
     <p><strong>(g) </strong>Without limiting any other terms of this Agreement, you
             must comply with all applicable third-party terms of agreement when using the App Store Sourced
-            Application.</strong></p>
-    <p><strong>14.14 </strong><strong>Consumer Complaints.</strong>&nbsp;
+            Application.</p>
+    <p><strong>14.14 Consumer Complaints.</strong>&nbsp;
             In accordance with California Civil Code &sect;1789.3, you may report complaints to the Complaint Assistance
             Unit of the Division of Consumer Services of the California Department of Consumer Affairs by contacting
             them in writing at 1625 North Market Blvd., Suite N 112, Sacramento, CA 95834, or by telephone at (800)
-            952-5210.</strong></p>
-    <p><strong>14.15 </strong><strong>Entire Agreement.</strong>&nbsp; This
+            952-5210.</p>
+    <p><strong>14.15 Entire Agreement.</strong>&nbsp; This
             Agreement is the final, complete and exclusive agreement of the parties with respect to the subject matter
             hereof and supersedes and merges all prior discussions between the parties with respect to such subject
-            matter.</strong></p>
-    <div>
-        <p><span>Released 23 April 2020</strong>&nbsp;</strong></p>
-        <p></strong></p>
-    </div>
+            matter.</p>
 </body>
 
 </html>

--- a/app/locales/eula/en_html.js
+++ b/app/locales/eula/en_html.js
@@ -23,49 +23,49 @@ export default `
     <p><strong>Last Updated Date: April 23, 2020</strong></p>
     <p>PLEASE READ THIS TERMS OF USE AGREEMENT (THE “TERMS
             OF USE” </strong>OR “AGREEMENT”
-                    ) CAREFULLY. &nbsp;THE SAFE PATH MOBILE APPLICATION (THE “APPLICATION”
+                    ) CAREFULLY. THE SAFE PATH MOBILE APPLICATION (THE “APPLICATION”
             </strong>), AND THE FEATURES AND INFORMATION IN IT ARE
             CONTROLLED BY PATH CHECK, INC. (“PCI</strong>”).
-            &nbsp;THESE TERMS OF USE GOVERN THE USE OF THE APPLICATION AND APPLY TO ALL USERS USING THE APPLICATION IN
+            THESE TERMS OF USE GOVERN THE USE OF THE APPLICATION AND APPLY TO ALL USERS USING THE APPLICATION IN
             ANY WAY, INCLUDING THE FEATURES THEREIN. BY CLICKING ON THE “I ACCEPT” BUTTON AND/OR DOWNLOADING
             THE APPLICATION, YOU REPRESENT THAT (1) YOU HAVE READ, UNDERSTAND, AND AGREE TO BE BOUND BY THE TERMS OF
             USE, (2) YOU ARE OF LEGAL AGE TO FORM A BINDING CONTRACT WITH PCI, AND (3) YOU HAVE THE AUTHORITY TO ENTER
-            INTO THE TERMS OF USE. &nbsp;IF YOU DO NOT AGREE TO BE BOUND BY THE TERMS OF USE,
+            INTO THE TERMS OF USE. IF YOU DO NOT AGREE TO BE BOUND BY THE TERMS OF USE,
             YOU MAY NOT ACCESS OR USE THE APPLICATION.</p>
     <p><strong>PLEASE BE AWARE THAT SECTION 13 OF THIS AGREEMENT, BELOW, CONTAINS PROVISIONS
             GOVERNING HOW DISPUTES THAT YOU AND WE HAVE AGAINST EACH OTHER ARE RESOLVED, INCLUDING, WITHOUT LIMITATION,
             ANY DISPUTES THAT AROSE OR WERE ASSERTED PRIOR TO THE EFFECTIVE DATE OF THIS AGREEMENT. IN PARTICULAR, IT
             CONTAINS AN ARBITRATION AGREEMENT WHICH WILL, WITH LIMITED EXCEPTIONS, REQUIRE DISPUTES BETWEEN US TO BE
-            SUBMITTED TO BINDING AND FINAL ARBITRATION. &nbsp;UNLESS YOU OPT OUT OF THE ARBITRATION AGREEMENT: (1) YOU
+            SUBMITTED TO BINDING AND FINAL ARBITRATION. UNLESS YOU OPT OUT OF THE ARBITRATION AGREEMENT: (1) YOU
             WILL ONLY BE PERMITTED TO PURSUE DISPUTES OR CLAIMS AND SEEK RELIEF AGAINST US ON AN INDIVIDUAL BASIS, NOT
             AS A PLAINTIFF OR CLASS MEMBER IN ANY CLASS OR REPRESENTATIVE ACTION OR PROCEEDING; AND (2) YOU ARE WAIVING
             YOUR RIGHT TO PURSUE DISPUTES OR CLAIMS AND SEEK RELIEF IN A COURT OF LAW AND TO HAVE A JURY TRIAL.
-            &nbsp;</strong></p>
+            </strong></p>
     <p><strong>ANY DISPUTE, CLAIM OR REQUEST FOR RELIEF RELATING IN ANY WAY TO YOUR USE OF THE
             APPLICATION WILL BE GOVERNED AND INTERPRETED BY AND UNDER THE LAWS OF THE COMMONWEALTH OF MASSACHUSETTS,
             CONSISTENT WITH THE FEDERAL ARBITRATION ACT, WITHOUT GIVING EFFECT TO ANY PRINCIPLES THAT PROVIDE FOR THE
-            APPLICATION OF THE LAW OF ANY OTHER JURISDICTION. &nbsp;THE UNITED NATIONS CONVENTION ON CONTRACTS FOR THE
+            APPLICATION OF THE LAW OF ANY OTHER JURISDICTION. THE UNITED NATIONS CONVENTION ON CONTRACTS FOR THE
             INTERNATIONAL SALE OF GOODS IS EXPRESSLY EXCLUDED FROM THIS AGREEMENT. </strong></p>
     <p>PLEASE NOTE THAT <strong>THIS AGREEMENT IS SUBJECT TO CHANGE BY PCI
-            IN ITS SOLE DISCRETION AT ANY TIME</strong>. &nbsp;When changes are made, PCI will make a new
-            copy of the Terms of Use available within the Application. &nbsp;We will also update the “Last
-            Updated” date at the top of the Terms of Use. &nbsp;Your continued use of the Application after a
-            change to the Terms of Use is made constitutes acceptance. &nbsp;PLEASE REGULARLY CHECK THE APPLICATION TO
+            IN ITS SOLE DISCRETION AT ANY TIME</strong>. When changes are made, PCI will make a new
+            copy of the Terms of Use available within the Application. We will also update the “Last
+            Updated” date at the top of the Terms of Use. Your continued use of the Application after a
+            change to the Terms of Use is made constitutes acceptance. PLEASE REGULARLY CHECK THE APPLICATION TO
             VIEW THE MOST CURRENT TERMS.</p>
-    <p><strong>1. USE OF THE APPLICATION.</strong>&nbsp;
+    <p><strong>1. USE OF THE APPLICATION.</strong>
         </strong></p>
-    <p><strong>1.1 Definitions</strong>. &nbsp;As used in
+    <p><strong>1.1 Definitions</strong>. As used in
             these Terms of Use, the following definitions apply:</p>
     <p><strong>“App User</strong>” means an
             individual natural person who has downloaded the Application under these Terms of Use.</p>
     <p><strong>“Location History</strong>”
-            means location data collected from an App User&rsquo;s mobile device leveraging GPS, Bluetooth and/or other
+            means location data collected from an App User’s mobile device leveraging GPS, Bluetooth and/or other
             features or software, that the App User elects to have recorded and stored within the Application installed
-            on the App User&rsquo;s mobile device.</p>
+            on the App User’s mobile device.</p>
     <p><strong>“Publicly Available Safe Places Data</strong>
             ” means anonymized maps of public places where individuals diagnosed with Covid-19 have
             visited and data files of times they visited such places, as compiled and created by a third party, and made
-            available via such third party&rsquo;s Third Party Safe Places Web App.</p>
+            available via such third party’s Third Party Safe Places Web App.</p>
     <p><strong>“Safe Places Software</strong>”
             means open-source software, available at </strong><span class="c8"><a class="c11"
                 href="https://www.google.com/url?q=https://github.com/tripleblindmarket/safe-places&amp;sa=D&amp;ust=1587722145899000">https://github.com/tripleblindmarket/safe-places</a></strong>
@@ -76,140 +76,140 @@ export default `
             agency, that employs Safe Places Software to, among other things, publish Publicly Available Safe Places
             Data.</p>
     <p><strong>1.2 Application Features and Functionality.</strong>
-            &nbsp; The Application is designed to enable App Users, </strong><span class="c13 c16">at their
+             The Application is designed to enable App Users, </strong><span class="c13 c16">at their
             option</span>: (a) to record their Location History and to store such data locally in the
             Application downloaded to their mobile device, (b) to access Publicly Available Safe Places Data from one or
             more Third Party Safe Places Web Apps and download it to the Safe Paths App downloaded on their mobile
-            device, and (c) to share their stored Location History with third parties that they choose. &nbsp;
+            device, and (c) to share their stored Location History with third parties that they choose. 
     </p>
     <p><strong>1.3 Application License. </strong>The
             Application and the information and content available therein are protected by copyright laws throughout the
-            world. &nbsp;Subject to your compliance with this Agreement, PCI grants you a limited non-exclusive,
+            world. Subject to your compliance with this Agreement, PCI grants you a limited non-exclusive,
             non-transferable, non-sublicensable, revocable license to download, install and use a copy of the
             Application on a single mobile device or computer that you own or control and to run such copy of the
-            Application solely for your own personal or internal business purposes. &nbsp;Certain components or
+            Application solely for your own personal or internal business purposes. Certain components or
             libraries included in or bundled with the Application constitute open source software and are licensed under
-            open source licenses. &nbsp;To the extent required by such open source licenses, the terms of such licenses
+            open source licenses. To the extent required by such open source licenses, the terms of such licenses
             will apply in lieu of the terms of this Section 1.3, solely with respect to those components or libraries
-            that are licensed under such open source licenses. &nbsp;For a copy of such open source licenses, visit
+            that are licensed under such open source licenses. For a copy of such open source licenses, visit
         </strong><span class="c8"><a class="c11"
                 href="https://www.google.com/url?q=https://github.com/tripleblindmarket/covid-safe-paths/blob/develop/LICENSE&amp;sa=D&amp;ust=1587722145900000">https://github.com/tripleblindmarket/covid-safe-paths/blob/develop/LICENSE</a></strong>
-                        . &nbsp;Furthermore, with respect to any Application accessed through or downloaded from the
-            Apple App Store (an&nbsp;“App Store Sourced Application”</strong>
+                        . Furthermore, with respect to any Application accessed through or downloaded from the
+            Apple App Store (an“App Store Sourced Application”</strong>
                       ), you will only use the App Store Sourced Application (a) on an Apple-branded product that runs
-            the iOS (Apple&rsquo;s proprietary operating system) and (b) as permitted by the “Usage Rules”
+            the iOS (Apple’s proprietary operating system) and (b) as permitted by the “Usage Rules”
             set forth in the Apple App Store Terms of Service. Notwithstanding the first sentence in this section, with
             respect to any Application accessed through or downloaded from the Google Play store (a “
             Google Play Sourced Application</strong>”), you may have additional
             license rights with respect to use of the Application on a shared basis within your designated family
             group.</p>
-    <p id="h.gjdgxs"><strong>1.4 Updates.</strong>&nbsp;
+    <p id="h.gjdgxs"><strong>1.4 Updates.</strong>
             You understand that to keep the Application most useful for App Users and to accommodate bug fixes and other
             technological changes, PCI may make updates to the Application after you download the Application.
-            &nbsp;These updates will be made available to App Users from the third party from whom you received the
+            These updates will be made available to App Users from the third party from whom you received the
             Application license, e.g., the Apple App Store or Google Play (each, an “App Store
-            ”</strong>). &nbsp;You will have the ability, at your
+            ”</strong>). You will have the ability, at your
             option, to download any updates to the Application that we make freely available through such channels.
-            &nbsp;We do not require you to install any updates in order for you to continue using the Application after
-            we make such updates available. &nbsp;This is because we do not retain any information about you when you
-            download the Application. &nbsp;Therefore, we will not know whether you have installed any such updates.
-            &nbsp;Accordingly, you acknowledge and agree that if you elect NOT to install available updates, the
+            We do not require you to install any updates in order for you to continue using the Application after
+            we make such updates available. This is because we do not retain any information about you when you
+            download the Application. Therefore, we will not know whether you have installed any such updates.
+            Accordingly, you acknowledge and agree that if you elect NOT to install available updates, the
             Application may not operate in accordance with publicly available documentation regarding the features and
             functionality of the Application, which documentation may be updated after the time you originally
-            downloaded it. &nbsp;In addition, you may need to update third-party software from time to time in order to
-            use the Application. &nbsp;Any updates issued by PCI and installed by you shall be deemed the Application
+            downloaded it. In addition, you may need to update third-party software from time to time in order to
+            use the Application. Any updates issued by PCI and installed by you shall be deemed the Application
             and shall be governed by this Safe Places EULA or any subsequent end user license agreement accompanying the
             update.</strong></p>
     <p><strong>1.5 Necessary Equipment and Software.</strong>
-            &nbsp; You must provide all equipment and software necessary to download and use the Application
+             You must provide all equipment and software necessary to download and use the Application
             and to connect to any third party services or sites, including but not limited to, a mobile device that is
-            suitable to connect with and use the Application. &nbsp;You are solely responsible for any fees, including
-            Internet connection or mobile fees, that you incur when accessing the Application. &nbsp;</p>
+            suitable to connect with and use the Application. You are solely responsible for any fees, including
+            Internet connection or mobile fees, that you incur when accessing the Application. </p>
     <p><strong>1.6 Responsibility for Location History and Other Data
-            Collected and Stored by You. </strong>&nbsp;PCI has no access to the Location History or any
+            Collected and Stored by You. </strong>PCI has no access to the Location History or any
             other data you collect, receive and store in the installed Application or otherwise on your mobile device.
-            &nbsp;Therefore, PCI has no responsibility or liability for the deletion or accuracy of the Location History
+            Therefore, PCI has no responsibility or liability for the deletion or accuracy of the Location History
             or other data you collect, receive or store in the Application or the failure to store, transmit or receive
             transmission of Location History or other data; or the security, privacy, storage, or transmission of other
-            communications originating with or involving use of the Application. &nbsp;</p>
+            communications originating with or involving use of the Application. </p>
     <p><strong>2. OWNERSHIP.</strong></p>
-    <p><strong>2.1 Application.</strong>&nbsp; Except with
+    <p><strong>2.1 Application.</strong> Except with
             respect to your Location History and other data you may collect, retrieve from third parties and store in
             the Application on your device, you agree that PCI and its suppliers own all rights, title and interest in
-            and to the Application. &nbsp;You will not remove, alter or obscure any copyright, trademark, service mark
+            and to the Application. You will not remove, alter or obscure any copyright, trademark, service mark
             or other proprietary rights notices incorporated in or accompanying the Application.</p>
-    <p><strong>2.2 Trademarks.</strong>&nbsp;COVID Safe
+    <p><strong>2.2 Trademarks.</strong>COVID Safe
             Paths and all related graphics, logos, service marks and trade names used on or in connection with the
             Application or in connection therewith are the trademarks of PCI and may not be used without permission in
-            connection with your, or any third-party, products or services. &nbsp;Other trademarks, service marks and
+            connection with your, or any third-party, products or services. Other trademarks, service marks and
             trade names that may appear on or in the Application are the property of their respective owners.</p>
     <p><strong>3. COLLECTION AND USE OF YOUR PERSONAL
-            INFORMATION.&nbsp; </strong>You acknowledge that the Application
+            INFORMATION. </strong>You acknowledge that the Application
             may collect personal information about you (through your choice to store information in the Application or
-            through automatic technology tools), including your Location History. &nbsp;You acknowledge that the
+            through automatic technology tools), including your Location History. You acknowledge that the
             Application may provide you with opportunities to share personal information about yourself, including your
             Location History with others. All personal information in connection with this Application is subject to our
             Privacy Policy. By downloading, installing, using, and providing personal information to or through this
             Application, you consent to all actions taken by us with respect to your personal information in compliance
-            with the Privacy Policy. &nbsp;For some features of the Application, specific consent is required. &nbsp;In
+            with the Privacy Policy. For some features of the Application, specific consent is required. In
             addition, you may choose to disclose, through other means not associated with the Application, any part of
             your personal information to family members, doctors, health care providers, governmental agencies, or other
-            individuals or entities. &nbsp;We recommend that you make your choices regarding sharing your personal
-            information, through the Application or otherwise, carefully. &nbsp;We will have no liability for any
+            individuals or entities. We recommend that you make your choices regarding sharing your personal
+            information, through the Application or otherwise, carefully. We will have no liability for any
             consequences that may result because you have released or shared information, through the Application or
-            otherwise, with a third party. &nbsp;</p>
-    <p><strong>4. FEEDBACK</strong>. &nbsp;If you provide
+            otherwise, with a third party. </p>
+    <p><strong>4. FEEDBACK</strong>. If you provide
             PCI with any ideas, suggestions, documents, and/or proposals (“Feedback”
             </strong>) via email or another means, you do so at your
             own risk and you acknowledge and agree that PCI has no obligations (including without limitation obligations
-            of confidentiality) with respect to such Feedback. &nbsp;You represent and warrant that you have all rights
-            necessary to submit the Feedback. &nbsp;You hereby grant to PCI a fully paid, royalty-free, perpetual,
+            of confidentiality) with respect to such Feedback. You represent and warrant that you have all rights
+            necessary to submit the Feedback. You hereby grant to PCI a fully paid, royalty-free, perpetual,
             irrevocable, worldwide, non-exclusive, and fully sublicensable right and license to use, reproduce, perform,
             display, distribute, adapt, modify, re-format, create derivative works of, and otherwise commercially or
             non-commercially exploit in any manner, any and all Feedback, and to sublicense the foregoing rights, in
             connection with the operation and maintenance of the Application, any other PCI products or services, or
-            PCI&rsquo;s &nbsp;business.</p>
+            PCI’s business.</p>
     <p><strong>5. APP STORES.
-            &nbsp;</strong>You acknowledge and agree that the availability of the Application is
-            dependent on the App Store from whom you received the Application license. &nbsp;You acknowledge that this
-            Agreement is between you and PCI and not with the App Store. &nbsp;PCI, not the App Store, is solely
+            </strong>You acknowledge and agree that the availability of the Application is
+            dependent on the App Store from whom you received the Application license. You acknowledge that this
+            Agreement is between you and PCI and not with the App Store. PCI, not the App Store, is solely
             responsible for the Application, including the content PCI makes available therein, and the maintenance,
             support services, and warranty therefor, and addressing any claims relating thereto (e.g., product
-            liability, legal compliance or intellectual property infringement). &nbsp;In order to use the Application,
+            liability, legal compliance or intellectual property infringement). In order to use the Application,
             you must have access to a wireless network, and you agree to pay all fees associated with such access.
-            &nbsp;You also agree to pay all fees (if any) charged by the App Store in connection with the Application.
-            &nbsp;You agree to comply with, and your license to use the Application is conditioned upon your compliance
+            You also agree to pay all fees (if any) charged by the App Store in connection with the Application.
+            You agree to comply with, and your license to use the Application is conditioned upon your compliance
             with all terms of agreement imposed by the applicable App Store when using the Application. You acknowledge
             that the App Store (and its subsidiaries) are third-party beneficiaries of this Agreement and will have the
             right to enforce it.</p>
-    <p><strong>6. FEES. &nbsp;</strong>No fees shall be
+    <p><strong>6. FEES. </strong>No fees shall be
             payable under this Agreement for the rights granted under this Agreement. You acknowledge and agree that
             this fee arrangement is made in consideration for the mutual covenants set forth in this Agreement,
             including your obligations hereunder, and the disclaimers, exclusions, and limitations of liability set
             forth herein.</p>
-    <p><strong>7. INDEMNIFICATION. &nbsp;</strong>You
+    <p><strong>7. INDEMNIFICATION. </strong>You
             agree to indemnify and hold PCI, its parents, subsidiaries, affiliates, officers, employees, volunteers,
             agents, partners, suppliers, and licensors (each, a “PCI Party
                       ” and collectively, the “PCI Parties”
                       ) harmless from any losses, costs, liabilities and expenses (including reasonable
-            attorneys&rsquo; fees) relating to or arising out of any and all of the following: (a) your use of, or
+            attorneys’ fees) relating to or arising out of any and all of the following: (a) your use of, or
             inability to use the Application; (b) your violation of this Agreement; (c) your violation of any rights of
-            another party; or (d) your violation of any applicable laws, rules or regulations. &nbsp;PCI reserves the
+            another party; or (d) your violation of any applicable laws, rules or regulations. PCI reserves the
             right, at its own cost, to assume the exclusive defense and control of any matter otherwise subject to
             indemnification by you, in which event you will fully cooperate with PCI in asserting any available
-            defenses. &nbsp;This provision does not require you to indemnify any of the PCI Parties for any
-            unconscionable commercial practice by such party or for such party&rsquo;s fraud, deception, false promise,
+            defenses. This provision does not require you to indemnify any of the PCI Parties for any
+            unconscionable commercial practice by such party or for such party’s fraud, deception, false promise,
             misrepresentation or concealment, suppression or omission of any material fact in connection with the
             Application provided hereunder. You agree that the provisions in this section will survive any termination
             of this Agreement and/or your use of or access to Application.</p>
     <p><strong>8. DISCLAIMER OF WARRANTIES AND CONDITIONS.</strong></p>
-    <p><strong>8.1 As Is.</strong>&nbsp;YOU EXPRESSLY
+    <p><strong>8.1 As Is.</strong>YOU EXPRESSLY
             UNDERSTAND AND AGREE THAT TO THE EXTENT PERMITTED BY APPLICABLE LAW, YOUR USE OF THE APPLICATION IS AT YOUR
             SOLE RISK, AND THE APPLICATION IS PROVIDED ON AN “AS IS” AND “AS AVAILABLE” BASIS,
-            WITH ALL FAULTS. &nbsp;THE PCI PARTIES EXPRESSLY DISCLAIM ALL WARRANTIES, REPRESENTATIONS, AND CONDITIONS OF
+            WITH ALL FAULTS. THE PCI PARTIES EXPRESSLY DISCLAIM ALL WARRANTIES, REPRESENTATIONS, AND CONDITIONS OF
             ANY KIND, WHETHER EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OR CONDITIONS OF
             MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARISING FROM USE OF THE APPLICATION.
-            &nbsp;</p>
+            </p>
     <p><strong>(a) </strong>THE PCI PARTIES MAKE NO WARRANTY, REPRESENTATION OR
             CONDITION THAT: (1) THE APPLICATION OR ITS FEATURES WILL MEET YOUR REQUIREMENTS; (2) YOUR USE OF THE
             APPLICATION WILL BE UNINTERRUPTED, TIMELY, SECURE OR ERROR-FREE; OR (3) THE RESULTS THAT MAY BE OBTAINED
@@ -219,175 +219,175 @@ export default `
             PROPERTY, INCLUDING, BUT NOT LIMITED TO, YOUR COMPUTER SYSTEM AND ANY DEVICE YOU USE TO ACCESS THE
             APPLICATION, OR ANY OTHER LOSS THAT RESULTS FROM ACCESSING SUCH CONTENT.</p>
     <p><strong>(c) </strong>THE AVAILABILITY OF THE APPLICATION AND ITS FEATURES MAY
-            BE SUBJECT TO DELAYS, CANCELLATIONS AND OTHER DISRUPTIONS. &nbsp;PCI MAKES NO WARRANTY, REPRESENTATION OR
+            BE SUBJECT TO DELAYS, CANCELLATIONS AND OTHER DISRUPTIONS. PCI MAKES NO WARRANTY, REPRESENTATION OR
             CONDITION WITH RESPECT TO THE APPLICATION OR ITS FEATURES, INCLUDING BUT NOT LIMITED TO, THE QUALITY,
             EFFECTIVENESS, REPUTATION AND OTHER CHARACTERISTICS THEREOF.</p>
     <p><strong>(d) </strong>NO ADVICE OR INFORMATION, WHETHER ORAL OR WRITTEN,
             OBTAINED FROM PCI OR THROUGH THE APPLICATION WILL CREATE ANY WARRANTY NOT EXPRESSLY MADE HEREIN.</p>
     <p><strong>(e) </strong>FROM TIME TO TIME, PCI MAY OFFER NEW “BETA”
-            FEATURES OR TOOLS WITH WHICH ITS USERS MAY EXPERIMENT. &nbsp;SUCH FEATURES OR TOOLS ARE OFFERED SOLELY FOR
+            FEATURES OR TOOLS WITH WHICH ITS USERS MAY EXPERIMENT. SUCH FEATURES OR TOOLS ARE OFFERED SOLELY FOR
             EXPERIMENTAL PURPOSES AND WITHOUT ANY WARRANTY OF ANY KIND, AND MAY BE MODIFIED OR DISCONTINUED AT
-            PCI&rsquo;S SOLE DISCRETION. &nbsp;THE PROVISIONS OF THIS SECTION APPLY WITH FULL FORCE TO SUCH FEATURES OR
+            PCI’S SOLE DISCRETION. THE PROVISIONS OF THIS SECTION APPLY WITH FULL FORCE TO SUCH FEATURES OR
             TOOLS.</p>
     <p><strong>8.2 NOT INTENDED AS MEDICAL ADVICE.</strong>
-            &nbsp;YOU ACKNOWLEDGE THAT THE INFORMATION IN THE APPLICATION IS PROVIDED FOR GENERAL
+            YOU ACKNOWLEDGE THAT THE INFORMATION IN THE APPLICATION IS PROVIDED FOR GENERAL
             INFORMATIONAL PURPOSES ONLY. IT IS NOT INTENDED AS MEDICAL ADVICE OF ANY KIND NOR IS IT INTENDED TO
-            DIAGNOSE, TREAT, CURE OR PREVENT ANY DISEASE OR MEDICAL CONDITION. &nbsp;THE INFORMATION PRESENTED IN THE
+            DIAGNOSE, TREAT, CURE OR PREVENT ANY DISEASE OR MEDICAL CONDITION. THE INFORMATION PRESENTED IN THE
             APPLICATION SHOULD NOT BE INTERPRETED OR CONSTRUED IN ANY WAY AS A REPLACEMENT OR SUBSTITUTE FOR MEDICAL
-            ADVICE PROVIDED BY YOUR DOCTOR OR OTHER QUALIFIED HEALTHCARE PROVIDER. &nbsp;YOU SHOULD NOT DISREGARD, AVOID
+            ADVICE PROVIDED BY YOUR DOCTOR OR OTHER QUALIFIED HEALTHCARE PROVIDER. YOU SHOULD NOT DISREGARD, AVOID
             OR DELAY OBTAINING MEDICAL ADVICE OR TREATMENT FROM YOUR DOCTOR OR OTHER QUALIFIED HEALTHCARE PROVIDER DUE
             TO ANY INFORMATION PROVIDED IN THE APPLICATION. UNDER NO CIRCUMSTANCES SHOULD YOU ALTER YOUR EXISTING
             MEDICAL TREATMENT, MEDICATION REGIMEN, OR ANY OTHER RELATED HEALTHCARE ACTIVITIES BASED ON ANY INFORMATION
             PROVIDED IN THE APPLICATION. IT IS IMPORTANT FOR YOU TO DISCUSS YOUR TREATMENT OPTIONS, AND ANY QUESTIONS
             THAT YOU MAY HAVE, WITH YOUR DOCTOR OR OTHER QUALIFIED HEALTHCARE PROVIDER.</p>
     <p><strong>8.3 </strong>In making the Application available for download,
-            PCI&rsquo;s goal is to provide individuals with a useful tool for contact tracing. &nbsp;However, the
-            utility of the Application&rsquo;s features is dependent upon a number of factors that are outside the
+            PCI’s goal is to provide individuals with a useful tool for contact tracing. However, the
+            utility of the Application’s features is dependent upon a number of factors that are outside the
             control of PCI, such as the reliability of GPS sensors, whether individuals are carrying their mobile
             devices, as well as the accuracy, reliability, availability, effectiveness or correct use of
-            individual&rsquo;s mobile devices and GPS sensors, all of which are used to create Location History, and for
+            individual’s mobile devices and GPS sensors, all of which are used to create Location History, and for
             any Publicly Available Safe Places Data that you may upload into your Application from third party source,
-            the accuracy and completeness of such data. &nbsp;Your Location History or other data may be unavailable,
-            inaccurate or incomplete. &nbsp;Use of the Application should not replace your good judgment and common
-            sense. &nbsp;</p>
+            the accuracy and completeness of such data. Your Location History or other data may be unavailable,
+            inaccurate or incomplete. Use of the Application should not replace your good judgment and common
+            sense. </p>
     <p><strong>8.4 No Liability for Conduct of Third Parties.</strong>
-            &nbsp; YOU ACKNOWLEDGE AND AGREE THAT PCI PARTIES ARE NOT LIABLE, AND YOU AGREE NOT TO SEEK TO
+             YOU ACKNOWLEDGE AND AGREE THAT PCI PARTIES ARE NOT LIABLE, AND YOU AGREE NOT TO SEEK TO
             HOLD PCI PARTIES LIABLE, FOR THE CONDUCT OR OMISSIONS OF THIRD PARTIES, INCLUDING THE ACTIONS OF ANY THIRD
             PARTY OPERATING A THIRD PARTY SAFE PLACES WEB APP OR ANY GOVERNMENTAL AGENCY WITH WHICH YOU CHOOSE TO
             INTERACT IN CONNECTION WITH YOUR USE OF THE APPLICATION, AND THAT THE RISK OF INJURY FROM SUCH THIRD PARTIES
             RESTS ENTIRELY WITH YOU.</p>
     <p><strong>9. LIMITATION OF LIABILITY.</strong></p>
     <p><strong>9.1 Disclaimer of Certain Damages.</strong>
-            &nbsp; YOU UNDERSTAND AND AGREE THAT IN NO EVENT SHALL THE PCI PARTIES BE LIABLE FOR ANY LOSS OF
+             YOU UNDERSTAND AND AGREE THAT IN NO EVENT SHALL THE PCI PARTIES BE LIABLE FOR ANY LOSS OF
             PROFITS, PERSONAL INJURY, PROPERTY DAMAGE, WRONGFUL DEATH, REVENUE OR DATA, INDIRECT, INCIDENTAL, SPECIAL,
             OR CONSEQUENTIAL DAMAGES, OR DAMAGES OR COSTS DUE TO LOSS OF PRODUCTION OR USE, BUSINESS INTERRUPTION,
             PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES, IN EACH CASE WHETHER OR NOT PCI HAS BEEN ADVISED OF THE
             POSSIBILITY OF SUCH DAMAGES, ARISING OUT OF OR IN CONNECTION WITH THIS AGREEMENT, ON ANY THEORY OF
             LIABILITY, RESULTING FROM: (1) THE USE OR INABILITY TO USE THE APPLICATION OR ANY OF ITS ADVERTISED
-            FEATURES; (2) &nbsp;UNAUTHORIZED ACCESS TO OR ALTERATION OF YOUR TRANSMISSIONS OR DATA; OR (3) ANY OTHER
+            FEATURES; (2) UNAUTHORIZED ACCESS TO OR ALTERATION OF YOUR TRANSMISSIONS OR DATA; OR (3) ANY OTHER
             MATTER RELATED TO THE APPLICATION, WHETHER BASED ON WARRANTY, COPYRIGHT, CONTRACT, TORT (INCLUDING
-            NEGLIGENCE), OR ANY OTHER LEGAL THEORY. &nbsp;THE FOREGOING CAP ON LIABILITY SHALL NOT APPLY TO LIABILITY OF
-            A PCI PARTY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY A PCI PARTY&rsquo;S NEGLIGENCE; OR FOR (B) ANY INJURY
-            CAUSED BY A PCI PARTY&rsquo;S FRAUD OR FRAUDULENT MISREPRESENTATION. </p>
-    <p><strong>9.2 Cap on Liability.</strong>&nbsp; TO THE
+            NEGLIGENCE), OR ANY OTHER LEGAL THEORY. THE FOREGOING CAP ON LIABILITY SHALL NOT APPLY TO LIABILITY OF
+            A PCI PARTY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY A PCI PARTY’S NEGLIGENCE; OR FOR (B) ANY INJURY
+            CAUSED BY A PCI PARTY’S FRAUD OR FRAUDULENT MISREPRESENTATION. </p>
+    <p><strong>9.2 Cap on Liability.</strong> TO THE
             MAXIMUM EXTENT PERMITTED BY LAW, NOTWITHSTANDING ANYTHING TO THE CONTRARY CONTAINED HEREIN, OUR LIABILITY TO
             YOU FOR ANY DAMAGES ARISING FROM OR RELATED TO THESE TERMS OF USE (FOR ANY CAUSE WHATSOEVER AND REGARDLESS
             OF THE FORM OF THE ACTION), WILL AT ALL TIMES BE LIMITED TO A MAXIMUM OF FIFTY US DOLLARS (U.S. $50). THE
-            EXISTENCE OF MORE THAN ONE CLAIM WILL NOT ENLARGE THIS LIMIT. &nbsp;YOU AGREE THAT OUR SUPPLIERS WILL HAVE
+            EXISTENCE OF MORE THAN ONE CLAIM WILL NOT ENLARGE THIS LIMIT. YOU AGREE THAT OUR SUPPLIERS WILL HAVE
             NO LIABILITY OF ANY KIND ARISING FROM OR RELATING TO THESE TERMS OF USE.</p>
-    <p><strong>9.3 Your Data.</strong>&nbsp; EXCEPT FOR
-            PCI&rsquo;S OBLIGATIONS TO PROTECT YOUR PERSONAL DATA AS SET FORTH IN THE PCI&rsquo;S PRIVACY POLICY, PCI
+    <p><strong>9.3 Your Data.</strong> EXCEPT FOR
+            PCI’S OBLIGATIONS TO PROTECT YOUR PERSONAL DATA AS SET FORTH IN THE PCI’S PRIVACY POLICY, PCI
             ASSUMES NO RESPONSIBILITY FOR THE TIMELINESS, DELETION, MIS-DELIVERY OR FAILURE TO STORE ANY CONTENT
             (INCLUDING YOUR LOCATION HISTORY), USER COMMUNICATIONS OR PERSONALIZATION SETTINGS.</p>
-    <p><strong>9.4 Basis of the Bargain.</strong>&nbsp;
+    <p><strong>9.4 Basis of the Bargain.</strong>
             THE LIMITATIONS OF DAMAGES SET FORTH ABOVE ARE FUNDAMENTAL ELEMENTS OF THE BASIS OF THE BARGAIN BETWEEN PCI
             AND YOU.</p>
     <p><strong>10. REMEDIES.</strong></p>
-    <p><strong>10.1 Violations.</strong>&nbsp; If PCI
+    <p><strong>10.1 Violations.</strong> If PCI
             becomes aware of any possible violations by you of this Agreement, PCI reserves the right to investigate
-            such violations. &nbsp;If, as a result of the investigation, PCI believes that criminal activity has
+            such violations. If, as a result of the investigation, PCI believes that criminal activity has
             occurred, PCI reserves the right to refer the matter to, and to cooperate with, any and all applicable legal
-            authorities. &nbsp;PCI is entitled, except to the extent prohibited by applicable law, to disclose any
+            authorities. PCI is entitled, except to the extent prohibited by applicable law, to disclose any
             information or materials you provide to PCI in connection with your use of the Application, to (a) comply
             with applicable laws, legal process or governmental request; (b) enforce these Terms of Use, (c) respond to
             your requests for customer service, or (d) protect the rights, property or personal safety of PCI or the
             public, and all enforcement or other government officials, as PCI, in its sole discretion believes to be
             necessary or appropriate.</p>
-    <p><strong>11. TERM AND TERMINATION. &nbsp;</strong></p>
-    <p><strong>11.1 Term.</strong>&nbsp; This Agreement
+    <p><strong>11. TERM AND TERMINATION. </strong></p>
+    <p><strong>11.1 Term.</strong> This Agreement
             commences on the date when you accept them (as described in the preamble above) and remain in full force and
             effect while you use the Application, unless terminated earlier in accordance with this Agreement.
     </p>
     <p><strong>11.2 Prior Use. </strong>
-            &nbsp;Notwithstanding the foregoing, you hereby acknowledge and agree that this Agreement
+            Notwithstanding the foregoing, you hereby acknowledge and agree that this Agreement
             commenced on the earlier to occur of (a) the date you first used the Application or (b) the date you
             accepted this Agreement and will remain in full force and effect while you use the Application, unless
             earlier terminated in accordance with this Agreement.</p>
-    <p><strong>11.3 Termination by You. &nbsp;</strong>If
+    <p><strong>11.3 Termination by You. </strong>If
             you want to terminate this Agreement, you may do so by deleting the Application from your mobile device.
-            &nbsp;</p>
-    <p><strong>11.4 Effect of Termination.</strong>&nbsp;
-            Termination of this Agreement requires you to delete the Application and cease all use of it. &nbsp;All
+            </p>
+    <p><strong>11.4 Effect of Termination.</strong>
+            Termination of this Agreement requires you to delete the Application and cease all use of it. All
             provisions of this Agreement which by their nature should survive, shall survive termination, including
             without limitation, ownership provisions, warranty disclaimers, and limitation of liability.</p>
-    <p><strong>12. INTERNATIONAL USERS. &nbsp;</strong>The
-            Application is intended solely for use in the United States of America. &nbsp;PCI makes no representations
-            that the Application is functional in other locations. &nbsp;Those who access or use the Application from
+    <p><strong>12. INTERNATIONAL USERS. </strong>The
+            Application is intended solely for use in the United States of America. PCI makes no representations
+            that the Application is functional in other locations. Those who access or use the Application from
             other countries do so at their own risk and are responsible for use in compliance with local law.</strong></p>
     <p id="h.30j0zll"><strong>13. DISPUTE RESOLUTION.</strong>
-            &nbsp; <strong>Please read the following
+             <strong>Please read the following
             arbitration agreement in this Section (“Arbitration Agreement
-            ”) carefully.&nbsp; It requires U.S. users to arbitrate disputes with PCI and limits the
-            manner in which you can seek relief from us. &nbsp;</strong></p>
+            ”) carefully. It requires U.S. users to arbitrate disputes with PCI and limits the
+            manner in which you can seek relief from us. </strong></p>
     <p id="h.1fob9te"><strong>13.1 Applicability of Arbitration
-            Agreement</strong>.&nbsp;You agree that any dispute, claim, or
+            Agreement</strong>.You agree that any dispute, claim, or
             request for relief relating in any way to your access or use of the Application or to any aspect of your
             relationship with PCI, will be resolved by binding arbitration, rather than in court, except that (1) you
             may assert claims or seek relief in small claims court if your claims qualify,; and (2) you or PCI may seek
             equitable relief in court for infringement or other misuse of intellectual property rights (such as
-            trademarks, trade dress, domain names, trade secrets, copyrights, and patents). &nbsp;<strong>
+            trademarks, trade dress, domain names, trade secrets, copyrights, and patents). <strong>
             This Arbitration Agreement shall apply, without limitation, to all disputes or claims and
             requests for relief that arose or were asserted before the effective date of this Agreement or any prior
-            version of this Agreement. </strong>&nbsp;</p>
+            version of this Agreement. </strong></p>
     <p><strong>13.2 Arbitration Rules and Forum</strong>
             The Federal Arbitration Act governs the interpretation and
-            enforcement of this Arbitration Agreement. &nbsp;To begin an arbitration proceeding, you must send a letter
+            enforcement of this Arbitration Agreement. To begin an arbitration proceeding, you must send a letter
             requesting arbitration and describing your dispute or claim or request for relief to our registered
-            agent&nbsp;Samuel Hoff c/o Pierce &amp; Mandell, P.C. 11
-            Beacon Street Suite 800, Boston MA 02108. &nbsp;The arbitration will be conducted by JAMS, an established
-            alternative dispute resolution provider.&nbsp;&nbsp;Disputes involving claims, counterclaims, or request for
-            relief under $250,000, not inclusive of attorneys&rsquo; fees and interest, shall be subject to JAMS&rsquo;s
+            agentSamuel Hoff c/o Pierce &amp; Mandell, P.C. 11
+            Beacon Street Suite 800, Boston MA 02108. The arbitration will be conducted by JAMS, an established
+            alternative dispute resolution provider.Disputes involving claims, counterclaims, or request for
+            relief under $250,000, not inclusive of attorneys’ fees and interest, shall be subject to JAMS’s
             most current version of the Streamlined Arbitration Rules and procedures available at
-            http://www.jamsadr.com/rules-streamlined-arbitration/; all other disputes shall be subject to JAMS&rsquo;s
+            http://www.jamsadr.com/rules-streamlined-arbitration/; all other disputes shall be subject to JAMS’s
             most current version of the Comprehensive Arbitration Rules and Procedures, available at
-            http://www.jamsadr.com/rules-comprehensive-arbitration/. &nbsp;JAMS&rsquo;s rules are also available at
-            www.jamsadr.com or by calling JAMS at 800-352-5267. &nbsp;If JAMS is not available to arbitrate, the parties
-            will select an alternative arbitral forum. &nbsp;If the arbitrator finds that you cannot afford to pay
-            JAMS&rsquo;s filing, administrative, hearing and/or other fees and cannot obtain a waiver from JAMS, PCI
-            will pay them for you. &nbsp;In addition, PCI will reimburse all such JAMS&rsquo;s filing, administrative,
+            http://www.jamsadr.com/rules-comprehensive-arbitration/. JAMS’s rules are also available at
+            www.jamsadr.com or by calling JAMS at 800-352-5267. If JAMS is not available to arbitrate, the parties
+            will select an alternative arbitral forum. If the arbitrator finds that you cannot afford to pay
+            JAMS’s filing, administrative, hearing and/or other fees and cannot obtain a waiver from JAMS, PCI
+            will pay them for you. In addition, PCI will reimburse all such JAMS’s filing, administrative,
             hearing and/or other fees for disputes, claims, or requests for relief totaling less than $10,000 unless the
-            arbitrator determines the claims are frivolous. &nbsp;</p>
+            arbitrator determines the claims are frivolous. </p>
     <p>You may choose to have the arbitration conducted by telephone, based on written
-            submissions, or at another mutually agreed location. &nbsp;Any judgment on the award rendered by the
+            submissions, or at another mutually agreed location. Any judgment on the award rendered by the
             arbitrator may be entered in any court of competent jurisdiction. </p>
     <p><strong>13.3 Authority of Arbitrator</strong>
-            .&nbsp; The arbitrator shall have exclusive authority to (a) determine the scope and
+            . The arbitrator shall have exclusive authority to (a) determine the scope and
             enforceability of this Arbitration Agreement and (b) resolve any dispute related to the interpretation,
             applicability, enforceability or formation of this Arbitration Agreement including, but not limited to, any
-            assertion that all or any part of this Arbitration Agreement is void or voidable. &nbsp;The arbitration will
-            decide the rights and liabilities, if any, of you and PCI. &nbsp;The arbitration proceeding will not be
-            consolidated with any other matters or joined with any other cases or parties.&nbsp; The arbitrator shall
+            assertion that all or any part of this Arbitration Agreement is void or voidable. The arbitration will
+            decide the rights and liabilities, if any, of you and PCI. The arbitration proceeding will not be
+            consolidated with any other matters or joined with any other cases or parties. The arbitrator shall
             have the authority to grant motions dispositive of all or part of any claim. The arbitrator shall have the
             authority to award monetary damages and to grant any non-monetary remedy or relief available to an
-            individual under applicable law, the arbitral forum&rsquo;s rules, and this Agreement (including the
+            individual under applicable law, the arbitral forum’s rules, and this Agreement (including the
             Arbitration Agreement). The arbitrator shall issue a written award and statement of decision describing the
             essential findings and conclusions on which the award is based, including the calculation of any damages
-            awarded.&nbsp; The arbitrator has the same authority to award relief on an individual basis that a judge in
-            a court of law would have.&nbsp; The award of the arbitrator is final and binding upon you and us.&nbsp;
+            awarded. The arbitrator has the same authority to award relief on an individual basis that a judge in
+            a court of law would have. The award of the arbitrator is final and binding upon you and us.
         </p>
     <p><strong>13.4 Waiver of Jury Trial</strong>
-            .&nbsp; YOU AND PCI HEREBY WAIVE ANY CONSTITUTIONAL AND STATUTORY RIGHTS TO SUE IN COURT AND HAVE
-            A TRIAL IN FRONT OF A JUDGE OR A JURY. &nbsp;You and PCI are instead electing that all disputes, claims, or
+            . YOU AND PCI HEREBY WAIVE ANY CONSTITUTIONAL AND STATUTORY RIGHTS TO SUE IN COURT AND HAVE
+            A TRIAL IN FRONT OF A JUDGE OR A JURY. You and PCI are instead electing that all disputes, claims, or
             requests for relief shall be resolved by arbitration under this Arbitration Agreement, except as specified
-            in Section 13.1 above.&nbsp; An arbitrator can award on an individual basis the same damages and relief as a
-            court and must follow this Agreement as a court would. &nbsp;However, there is no judge or jury in
-            arbitration, and court review of an arbitration award is subject to very limited review. &nbsp;</p>
+            in Section 13.1 above. An arbitrator can award on an individual basis the same damages and relief as a
+            court and must follow this Agreement as a court would. However, there is no judge or jury in
+            arbitration, and court review of an arbitration award is subject to very limited review. </p>
     <p id="h.3znysh7"><strong>13.5 Waiver of Class or Other
-            Non-Individualized Relief</strong>.&nbsp; ALL DISPUTES, CLAIMS, AND REQUESTS FOR RELIEF
+            Non-Individualized Relief</strong>. ALL DISPUTES, CLAIMS, AND REQUESTS FOR RELIEF
             WITHIN THE SCOPE OF THIS ARBITRATION AGREEMENT MUST BE ARBITRATED ON AN INDIVIDUAL BASIS AND NOT ON A CLASS
             OR COLLECTIVE BASIS, ONLY INDIVIDUAL RELIEF IS AVAILABLE, AND CLAIMS OF MORE THAN ONE CUSTOMER OR USER
-            CANNOT BE ARBITRATED OR CONSOLIDATED WITH THOSE OF ANY OTHER CUSTOMER OR USER. &nbsp;If a decision is issued
-            stating that applicable law precludes enforcement of any of this subsection&rsquo;s limitations as to a
+            CANNOT BE ARBITRATED OR CONSOLIDATED WITH THOSE OF ANY OTHER CUSTOMER OR USER. If a decision is issued
+            stating that applicable law precludes enforcement of any of this subsection’s limitations as to a
             given dispute, claim, or request for relief, then such aspect must be severed from the arbitration and
-            brought into the State or Federal Courts located in the Commonwealth of Massachusetts. &nbsp;All other
-            disputes, claims, or requests for relief shall be arbitrated. &nbsp;</p>
+            brought into the State or Federal Courts located in the Commonwealth of Massachusetts. All other
+            disputes, claims, or requests for relief shall be arbitrated. </p>
     <p><strong>13.6 30-Day Right to Opt Out</strong>.
             You have the right to opt out of the provisions of this Arbitration Agreement by sending written notice of
             your decision to opt out to: </strong>legal@pathcheck.org</strong>, within 30
-            days after first becoming subject to this Arbitration Agreement. &nbsp;Your notice must include your name
+            days after first becoming subject to this Arbitration Agreement. Your notice must include your name
             and address, your email address, and an unequivocal statement that you want to opt out of this Arbitration
-            Agreement. &nbsp;If you opt out of this Arbitration Agreement, all other parts of this Agreement will
-            continue to apply to you. &nbsp;Opting out of this Arbitration Agreement has no effect on any other
+            Agreement. If you opt out of this Arbitration Agreement, all other parts of this Agreement will
+            continue to apply to you. Opting out of this Arbitration Agreement has no effect on any other
             arbitration agreements that you may currently have, or may enter in the future, with us.</p>
     <p><strong>13.7 Severability. </strong>
         </strong><span class="c4">Except as provided in subsection 13.5, if any part or parts of this Arbitration
@@ -404,83 +404,83 @@ export default `
             PCI at the following address: Path Check, Inc. PO Box 441621, Somerville MA 02144</p>
     <p><strong>14. GENERAL PROVISIONS.</strong></p>
     <p><strong>14.1 Electronic Communications.</strong>
-            &nbsp; The communications between you and PCI may take place via electronic means, whether you
+             The communications between you and PCI may take place via electronic means, whether you
             send PCI e-mails, or whether PCI posts notices in the Application or through updates made to the Application
-            in accordance with this Terms of Use or communicates with you via e-mail. &nbsp;For contractual purposes,
+            in accordance with this Terms of Use or communicates with you via e-mail. For contractual purposes,
             you (a) consent to receive communications from PCI in an electronic form; and (b) agree that all terms and
             conditions, agreements, notices, disclosures, and other communications that PCI provides to you
             electronically satisfy any legal requirement that such communications would satisfy if it were to be in
-            writing. &nbsp;The foregoing does not affect your statutory rights, including but not limited to the
+            writing. The foregoing does not affect your statutory rights, including but not limited to the
             Electronic Signatures in Global and National Commerce Act at 15 U.S.C. &sect;7001 et seq.
             (“E-Sign”).</p>
-    <p><strong>14.2 Release.</strong>&nbsp; You hereby
+    <p><strong>14.2 Release.</strong> You hereby
             release the PCI Parties and their successors from claims, demands, any and all losses, damages, rights, and
             actions of any kind, including personal injuries, death, and property damage, that is either directly or
             indirectly related to or arises from any interactions with or conduct of operators of Third Party Safe
             Places Web Apps, healthcare providers, governmental agencies, of any kind arising in connection with or as a
-            result of this Agreement or your use of the Application. &nbsp;If you are a California resident, you hereby
+            result of this Agreement or your use of the Application. If you are a California resident, you hereby
             waive California Civil Code Section 1542, which states, “A general release does not extend to claims
             that the creditor or releasing party does not know or suspect to exist in his or her favor at the time of
             executing the release and that, if known by him or her, would have materially affected his or her settlement
-            with the debtor or released party.” &nbsp;The foregoing release does not apply to any claims, demands,
+            with the debtor or released party.” The foregoing release does not apply to any claims, demands,
             or any losses, damages, rights and actions of any kind, including personal injuries, death or property
-            damage for any unconscionable commercial practice by a PCI Party or for such party&rsquo;s fraud, deception,
+            damage for any unconscionable commercial practice by a PCI Party or for such party’s fraud, deception,
             false, promise, misrepresentation or concealment, suppression or omission of any material fact in connection
-            with the Application &nbsp;provided hereunder.</p>
-    <p><strong>14.3 Assignment.</strong>&nbsp; This
+            with the Application provided hereunder.</p>
+    <p><strong>14.3 Assignment.</strong> This
             Agreement, and your rights and obligations hereunder, may not be assigned, subcontracted, delegated or
-            otherwise transferred by you without PCI&rsquo;s prior written consent, and any attempted assignment,
+            otherwise transferred by you without PCI’s prior written consent, and any attempted assignment,
             subcontract, delegation, or transfer in violation of the foregoing will be null and void.</p>
-    <p><strong>14.4 Force Majeure.</strong>&nbsp; PCI
+    <p><strong>14.4 Force Majeure.</strong> PCI
             shall not be liable for any delay or failure to perform resulting from causes outside its reasonable
             control, including, but not limited to, acts of God, war, terrorism, riots, embargos, acts of civil or
             military authorities, fire, floods, accidents, strikes or shortages of transportation facilities, fuel,
             energy, labor or materials. </p>
     <p><strong>14.5 Questions, Complaints, Claims.</strong>
-            &nbsp; If you have any questions, complaints or claims with respect to the Application, please
+             If you have any questions, complaints or claims with respect to the Application, please
             contact us at: support@pathcheck.org.</p>
-    <p><strong>14.6 Exclusive Venue.</strong>&nbsp; To the
+    <p><strong>14.6 Exclusive Venue.</strong> To the
             extent the parties are permitted under this Agreement to initiate litigation in a court, both you and PCI
             agree that all claims and disputes arising out of or relating to this Agreement will be litigated
             exclusively in the state or federal courts located in Boston, Massachusetts.</p>
     <p><strong>14.7 Governing Law </strong>THE TERMS AND
             ANY ACTION RELATED THERETO WILL BE GOVERNED AND INTERPRETED BY AND UNDER THE LAWS OF THE COMMONWEALTH OF
             MASSACHUSETTS, CONSISTENT WITH THE FEDERAL ARBITRATION ACT, WITHOUT GIVING EFFECT TO ANY PRINCIPLES THAT
-            PROVIDE FOR THE APPLICATION OF THE LAW OF ANOTHER JURISDICTION. &nbsp;THE UNITED NATIONS CONVENTION ON
+            PROVIDE FOR THE APPLICATION OF THE LAW OF ANOTHER JURISDICTION. THE UNITED NATIONS CONVENTION ON
             CONTRACTS FOR THE INTERNATIONAL SALE OF GOODS DOES NOT APPLY TO THIS AGREEMENT.</p>
-    <p><strong>14.8 Choice of Language.</strong>&nbsp; It
+    <p><strong>14.8 Choice of Language.</strong> It
             is the express wish of the parties that this Agreement and all related documents have been drawn up in
             English. </p>
-    <p><strong>14.9 Notice.</strong>&nbsp; You may give
-            notice to PCI at the following address:&nbsp;Path Check, Inc. PO Box 441621,
-            Somerville MA 02144.</strong>&nbsp; Such notice shall be deemed given when received by PCI by
+    <p><strong>14.9 Notice.</strong> You may give
+            notice to PCI at the following address:Path Check, Inc. PO Box 441621,
+            Somerville MA 02144.</strong> Such notice shall be deemed given when received by PCI by
             letter delivered by nationally recognized overnight delivery service or first class postage prepaid mail at
             the above address.</p>
-    <p><strong>14.10 Waiver.</strong>&nbsp; Any waiver or
+    <p><strong>14.10 Waiver.</strong> Any waiver or
             failure to enforce any provision of this Agreement on one occasion will not be deemed a waiver of any other
             provision or of such provision on any other occasion.</p>
-    <p><strong>14.11 Severability.</strong>&nbsp; If any
+    <p><strong>14.11 Severability.</strong> If any
             portion of this Agreement is held invalid or unenforceable, that portion shall be construed in a manner to
             reflect, as nearly as possible, the original intention of the parties, and the remaining portions shall
             remain in full force and effect.</p>
-    <p><strong>14.12 Export Control.</strong>&nbsp; You
+    <p><strong>14.12 Export Control.</strong> You
             may not use, export, import, or transfer the Application except as authorized by U.S. law, the laws of the
-            jurisdiction in which you obtained PCI Properties, and any other applicable laws. &nbsp;In particular, but
+            jurisdiction in which you obtained PCI Properties, and any other applicable laws. In particular, but
             without limitation, the Application may not be exported or re-exported (a) into any United States embargoed
-            countries, or (b) to anyone on the U.S. Treasury Department&rsquo;s list of Specially Designated Nationals
-            or the U.S. Department of Commerce&rsquo;s Denied Person&rsquo;s List or Entity List. By using the
+            countries, or (b) to anyone on the U.S. Treasury Department’s list of Specially Designated Nationals
+            or the U.S. Department of Commerce’s Denied Person’s List or Entity List. By using the
             Application, you represent and warrant that (y) you are not located in a country that is subject to a U.S.
             Government embargo, or that has been designated by the U.S. Government as a “terrorist
             supporting” country and (z) you are not listed on any U.S. Government list of prohibited or restricted
             parties. You also will not use the Application for any purpose prohibited by U.S. law, including the
             development, design, manufacture or production of missiles, nuclear, chemical or biological weapons.
-            &nbsp;You acknowledge and agree that products, services or technology provided by PCI are subject to the
-            export control laws and regulations of the United States. &nbsp;You shall comply with these laws and
+            You acknowledge and agree that products, services or technology provided by PCI are subject to the
+            export control laws and regulations of the United States. You shall comply with these laws and
             regulations and shall not, without prior U.S. government authorization, export, re-export, or transfer PCI
             products, services or technology, either directly or indirectly, to any country in violation of such laws
             and regulations.</p>
     <p><strong>14.13 Accessing and Downloading the Application from
-            iTunes.</strong>&nbsp; The following applies to any App Store Sourced Application accessed
+            iTunes.</strong> The following applies to any App Store Sourced Application accessed
             through or downloaded from the Apple App Store: </p>
     <p><strong>(a) </strong>You acknowledge and agree that (i) this Agreement is
             concluded between you and PCI only, and not Apple, and (ii) PCI, not Apple, is solely responsible for the
@@ -503,11 +503,11 @@ export default `
             protection or similar legislation.</p>
     <p><strong>(e) </strong>You and PCI acknowledge that, in the event of any
             third-party claim that the App Store Sourced Application or your possession and use of that App Store
-            Sourced Application infringes that third party&rsquo;s intellectual property rights, as between PCI and
+            Sourced Application infringes that third party’s intellectual property rights, as between PCI and
             Apple, PCI, not Apple, will be solely responsible for the investigation, defense, settlement and discharge
             of any such intellectual property infringement claim to the extent required by this Agreement. </p>
     <p><strong>(f) </strong>You and PCI acknowledge and agree that Apple, and
-            Apple&rsquo;s subsidiaries, are third-party beneficiaries of this Agreement as related to your license of
+            Apple’s subsidiaries, are third-party beneficiaries of this Agreement as related to your license of
             the App Store Sourced Application, and that, upon your acceptance of the terms and conditions of this
             Agreement, Apple will have the right (and will be deemed to have accepted the right) to enforce this
             Agreement as related to your license of the App Store Sourced Application against you as a third-party
@@ -515,12 +515,12 @@ export default `
     <p><strong>(g) </strong>Without limiting any other terms of this Agreement, you
             must comply with all applicable third-party terms of agreement when using the App Store Sourced
             Application.</p>
-    <p><strong>14.14 Consumer Complaints.</strong>&nbsp;
+    <p><strong>14.14 Consumer Complaints.</strong>
             In accordance with California Civil Code &sect;1789.3, you may report complaints to the Complaint Assistance
             Unit of the Division of Consumer Services of the California Department of Consumer Affairs by contacting
             them in writing at 1625 North Market Blvd., Suite N 112, Sacramento, CA 95834, or by telephone at (800)
             952-5210.</p>
-    <p><strong>14.15 Entire Agreement.</strong>&nbsp; This
+    <p><strong>14.15 Entire Agreement.</strong> This
             Agreement is the final, complete and exclusive agreement of the parties with respect to the subject matter
             hereof and supersedes and merges all prior discussions between the parties with respect to such subject
             matter.</p>

--- a/app/locales/eula/ht_html.js
+++ b/app/locales/eula/ht_html.js
@@ -353,7 +353,7 @@ export default `
 </p>
 <p><strong>9. LIMITASYON RESPONSABLITE.</strong></p>
 <p>
-  <strong>1.1</strong> Limit responsabilite nou de sèten domaj. OU KONPRANN AK
+  <strong>9.1</strong> Limit responsabilite nou de sèten domaj. OU KONPRANN AK
   dakò KI PA GEN EVÈNMAN PATI pati PCI YON RESPONSAB POU NENPT PÈS POU PROFIT,
   BLIJI PÈSONÈL, DANJE PWOPRIYETE, MOVE MALADI, ENFMASYON OSWA DONE, DANI
   INDIRÈT, ENSIDANS, ESPESYAL, OSWA DWA, OSWA DANYE oswa domaj OSWA KOTE POU
@@ -370,7 +370,7 @@ export default `
   ki te koze pa yon fwis PCI pati a oswa yon fo reprezantasyon FRAUDULENT.
 </p>
 <p>
-  <strong>1.2</strong> Kap sou Responsabilite. POU PWOJÈ maksimòm PEMISYE POU
+  <strong>9.2</strong> Kap sou Responsabilite. POU PWOJÈ maksimòm PEMISYE POU
   LWA, KI KOTE POU NENPAY NENPOT POU KONTW CONCH KI GENYEN LA, RESPONSABLITE NOU
   POU OU pou nenpòt domaj ki soti nan oswa ki gen rapò ak kondisyon sa yo pou
   itilize (pou nenpòt ki koz toutbon menm jan ak fòm nan AKSYON an), yo pral nan
@@ -380,19 +380,19 @@ export default `
   ki gen rapò ak kondisyon sa yo sèvi ak.
 </p>
 <p>
-  <strong>1.3</strong> Done ou. EKSEPTE pou OBLIGASYON PCI a PWOTEJE DONE
+  <strong>9.3</strong> Done ou. EKSEPTE pou OBLIGASYON PCI a PWOTEJE DONE
   PÈSONÈL OU jan li te etabli nan règleman prive PCI a, PCI sipoze pa gen okenn
   responsablite pou tan an, DELETION, MIS-livrezon oswa echèk magazen nenpòt ki
   kontni (ki enkli istwa lokasyon ou), itilizatè kominikasyon oswa anviwònman
   pèsonalizasyon.
 </p>
 <p>
-  <strong>1.4</strong> Baz negosyasyon an. Limit nan domaj ki etabli anwo yo se
+  <strong>9.4</strong> Baz negosyasyon an. Limit nan domaj ki etabli anwo yo se
   eleman fondamantal de baz la nan PAPA ant PCI ak ou.
 </p>
-<p><strong>2. KONSÈY.</strong></p>
+<p><strong>10. KONSÈY.</strong></p>
 <p>
-  <strong>2.1 Vyolasyon</strong>. Si PCI vin okouran nenpòt vyolasyon posib ke
+  <strong>10.1 Vyolasyon</strong>. Si PCI vin okouran nenpòt vyolasyon posib ke
   ou nan Akò sa a, PCI rezève dwa pou envestige vyolasyon sa yo. Si, kòm yon
   rezilta nan ankèt la, psi kwè ke gen aktivite kriminèl ki te fèt, PCI rezève
   dwa pou refere ka a, epi pou kolabore ak, nenpòt ak tout otorite legal ki
@@ -405,43 +405,43 @@ export default `
   oswa lòt ofisyèl gouvènman yo, kòm psi, nan. sèl diskresyon li kwè ke li
   nesesè oswa apwopriye.
 </p>
-<p><strong>3. Regleman ak sispansyon.</strong></p>
+<p><strong>11. Regleman ak sispansyon.</strong></p>
 <p>
-  <strong>3.1 Regleman.</strong> Akò sa a kòmanse nan dat la lè ou aksepte yo
+  <strong>11.1 Regleman.</strong> Akò sa a kòmanse nan dat la lè ou aksepte yo
   (jan sa dekri nan pre-an pi wo a) epi rete nan tout fòs ak efè pandan w ap
   itilize aplikasyon an, sòf si sispann pi bonè nan akò ak sa a Akò.
 </p>
 <p>
-  <strong>3.2 Itilize Anvan.</strong> Malgre sa ki endike anwo la a, ou rekonèt
+  <strong>11.2 Itilize Anvan.</strong> Malgre sa ki endike anwo la a, ou rekonèt
   epi mwen dakò ke Akò sa a te kòmanse nan pi bonè pou rive nan (a) dat ou te
   itilize Aplikasyon an oswa (b) dat ou te aksepte Kontra sa a epi w ap rete nan
   tout fòs ou pandan wap itilize. Aplikasyon an, sòf si li te sispann pi bonè
   dapre Akò sa a.
 </p>
 <p>
-  <strong>3.3 Revokasyon ou.</strong> Si ou vle mete fen nan Akò sa a, ou ka fè
+  <strong>11.3 Revokasyon ou.</strong> Si ou vle mete fen nan Akò sa a, ou ka fè
   sa pa efase aplikasyon an soti nan aparèy mobil ou.
 </p>
 <p>
-  <strong>3.4 Efè Termination</strong>. Fen nan akò sa a egzije pou ou efase
+  <strong>11.4 Efè Termination</strong>. Fen nan akò sa a egzije pou ou efase
   aplikasyon an ak sispann tout itilize nan li. Tout dispozisyon ki nan akò sa a
   ki pa nati yo ta dwe siviv, va siviv mete fen, ki gen ladan san limit,
   dispozisyon pwopriyetè, avètisman garanti, ak limitasyon de responsablite.
 </p>
 <p>
-  <strong>4. Itilizatè entènasyonal yo.</strong> Aplikasyon an fèt sèlman pou
+  <strong>12. Itilizatè entènasyonal yo.</strong> Aplikasyon an fèt sèlman pou
   itilize nan Etazini nan Amerik la. Psi pa fè okenn reprezantasyon ki
   aplikasyon an fonksyonèl nan lòt kote. Moun ki gen aksè oswa ki itilize
   aplikasyon an nan lòt peyi yo fè sa sou pwòp risk yo epi yo responsab pou
   itilize an konfòmite ak lwa lokal yo.
 </p>
 <p>
-  <strong>5. Rezolisyon dispit.</strong> Tanpri li akò arbitraj sa a nan Seksyon
+  <strong>13. Rezolisyon dispit.</strong> Tanpri li akò arbitraj sa a nan Seksyon
   sa a ("Akò Abitraj") avèk anpil atansyon. Li mande pou itilizatè Ameriken
   abitraj diskisyon avèk psi epi limite fason ou ka chèche sekou nan men nou.
 </p>
 <p>
-  <strong>5.1 Aplikablite nan Abitraj Akò.</strong> Ou dakò ke nenpòt dispit,
+  <strong>13.1 Aplikablite nan Abitraj Akò.</strong> Ou dakò ke nenpòt dispit,
   reklamasyon, oswa demann pou soulajman ki gen rapò nan nenpòt fason pou aksè
   ou oswa pou sèvi ak aplikasyon an oswa nan nenpòt ki aspè nan relasyon ou ak
   psi, yo pral rezoud pa abitraj obligatwa, olye ke nan tribinal, eksepte ke (1
@@ -454,7 +454,7 @@ export default `
   efektif akò sa a oswa nenpòt vèsyon anvan akò sa a.
 </p>
 <p>
-  <strong>5.2 Règ Abitraj ak Forum.</strong> Lwa sou Abitraj Federal la gouvène
+  <strong>13.2 Règ Abitraj ak Forum.</strong> Lwa sou Abitraj Federal la gouvène
   entèpretasyon ak ranfòsman akò sa a sou Abitraj. Pou kòmanse yon pwosedi
   abitraj, ou dwe voye yon lèt pou mande abitraj epi dekri konfli ou oswa
   reklamasyon ou oswa demann soulajman pou ajan ki anrejistre nou an, Samuel
@@ -482,7 +482,7 @@ export default `
   medyatè a ka antre nan nenpòt ki tribinal ki gen konpetans jiridiksyon.
 </p>
 <p>
-  <strong>5.3 Otorite nan abitrè.</strong> Medyatè a dwe gen otorite eksklizif
+  <strong>13.3 Otorite nan abitrè.</strong> Medyatè a dwe gen otorite eksklizif
   pou (a) detèmine sijè ki abòde lan ak aplikabite nan Akò sa a Abitraj ak (b)
   rezoud nenpòt dispit ki gen rapò ak entèpretasyon, aplikabilite, aplikab, oswa
   fòmasyon sa a Arbitraj Akò ki gen ladan, men pa limite a, nenpòt ki afirmasyon
@@ -500,7 +500,7 @@ export default `
   genyen. Prim nan medyatè a se final ak obligatwa pou ou ak pou nou.
 </p>
 <p>
-  <strong>5.4 Egzanpsyon pou jijman jiri.</strong> OU AK PCI SE RENSEYE KÈK DWA
+  <strong>13.4 Egzanpsyon pou jijman jiri.</strong> OU AK PCI SE RENSEYE KÈK DWA
   KONSTITISYONÈL AK STATWA POU VOJE NAN TRIBINAL AK YON JIJANS AN devan yon Jij
   oswa yon jiri. Oumenm ak PCI se olye pou chwazi tout diskisyon, reklamasyon,
   oswa demann pou soulajman yo dwe rezoud nan abitraj dapre Akò sou Abitraj sa
@@ -511,7 +511,7 @@ export default `
   limite.
 </p>
 <p>
-  <strong>5.5 Egzanpsyon pou Sekou Klas oswa Lòt ki pa Peye-endividyalize.</strong>
+  <strong>13.5 Egzanpsyon pou Sekou Klas oswa Lòt ki pa Peye-endividyalize.</strong>
   Tout diskisyon, reklamasyon, ak Demann pou soulajman nan domèn AKIT ARBITRE sa
   a dwe abrite sou yon baz endividyèl epi yo pa sou yon klas oswa baz kolektif,
   SÈLMAN POU gen soulajman endividyèl, ak reklamasyon nan plis pase yon kliyan
@@ -524,7 +524,7 @@ export default `
   pou sekou yo dwe abitraj.
 </p>
 <p>
-  <strong>5.6 Dwa 30-Jou yo chwazi pou soti.</strong> Ou gen dwa pou ou pa
+  <strong>13.6 Dwa 30-Jou yo chwazi pou soti.</strong> Ou gen dwa pou ou pa
   patisipe nan dispozisyon ki nan Kontra Abitraj sa a pa voye yon avi alekri sou
   desizyon ou a patisipe soti nan: legal@pathcheck.org, nan lespas 30 jou apre
   premye vin sijè a sa a Abitraj Akò. Avi ou a dwe enkli non ou ak adrès ou,
@@ -535,28 +535,28 @@ export default `
   tan kap vini an, avèk nou.
 </p>
 <p>
-  <strong>5.7 Divisibilite.</strong> Eksepte jan yo prevwa nan souseksyon 13.5,
+  <strong>13.7 Divisibilite.</strong> Eksepte jan yo prevwa nan souseksyon 13.5,
   si nenpòt pati oswa pati nan akò sa a Abitraj yo te jwenn anba lalwa a yo dwe
   valab oswa ki pa ka ranfòse, Lè sa a, tankou yon pati espesifik oswa pati va
   gen ki pa gen fòs ak efè epi yo pral koupe ak rès la nan Abitraj la. Akò va
   kontinye nan fòs plen ak efè.
 </p>
 <p>
-  <strong>5.8 Siviv nan Akò.</strong> Akò sa a Abitraj ap siviv mete fen nan
+  <strong>13.8 Siviv nan Akò.</strong> Akò sa a Abitraj ap siviv mete fen nan
   relasyon ou a ak psi.
 </p>
 <p>
-  <strong>5.9 Modifikasyon.</strong> Malgre nenpòt dispozisyon ki nan Kontra
+  <strong>13.9 Modifikasyon.</strong> Malgre nenpòt dispozisyon ki nan Kontra
   sa-a nan kontrè a, nou dakò ke si PCI fè nenpòt ki chanjman materyèl nan lavni
   sa a Abitraj Akò, ou ka rejte ki chanjman nan trant (30) jou de chanjman sa yo
   vin efektif pa ekri PCI nan adrès sa a: Path Check, Inc. PO Box 441621,
   Somerville, MA 02144
 </p>
 <p>
-  <strong>6. DISPOZISYON JENERAL YO<br /> </strong>
+  <strong>14. DISPOZISYON JENERAL YO<br /> </strong>
 </p>
 <p>
-  <strong>6.1 Kominikasyon elektwonik.</strong> Kominikasyon ant ou menm ak PCI
+  <strong>14.1 Kominikasyon elektwonik.</strong> Kominikasyon ant ou menm ak PCI
   ka pran plas atravè mwayen elektwonik, si ou voye yon imèl PCI, oswa si PCI
   poste avi nan Aplikasyon an oswa atravè mizajou yo te fè nan Aplikasyon an
   annakò avèk sa a Regleman pou Itilize oswa kominike avèk ou via- lapòs. Pou
@@ -568,7 +568,7 @@ export default `
   Komès Nasyonal nan 15 US.C. §7001 et seq. ("E-Siyen").
 </p>
 <p>
-  <strong>6.2 Lansman.</strong> Ou fin divilge Pèmi yo PCI ak siksesè yo soti
+  <strong>14.2 Lansman.</strong> Ou fin divilge Pèmi yo PCI ak siksesè yo soti
   nan reklamasyon, demand, nenpòt ak tout pèt, domaj, dwa, ak aksyon nenpòt
   kalite, ki gen ladan blesi pèsonèl, lanmò, ak domaj pwopriyete, ki se swa
   dirèkteman oswa endirèkteman ki gen rapò ak oswa rive soti nan nenpòt ki
@@ -588,61 +588,61 @@ export default `
   Aplikasyon an bay la anba a.
 </p>
 <p>
-  <strong>6.3 Plasman.</strong> Akò sa a, ak dwa ou yo ak obligasyon ki anba la
+  <strong>14.3 Plasman.</strong> Akò sa a, ak dwa ou yo ak obligasyon ki anba la
   a, pa ka asiyen, soutretan, delege oswa otreman transfere pa ou san ou pa
   konsantman PCI anvan ekri, ak nenpòt tantativ tantasyon, tretman, delegasyon,
   oswa transfè an vyolasyon sa ki ekri pi wo a pral nil epi yo anile. .
 </p>
 <p>
-  <strong>6.4 Fòs majè.</strong> PCI pa dwe responsab pou okenn reta oswa echèk
+  <strong>14.4 Fòs majè.</strong> PCI pa dwe responsab pou okenn reta oswa echèk
   nan fè rezilta ki soti nan kòz deyò kontwòl rezonab li yo, ki gen ladan, men
   pa limite a, zak Bondye a, lagè, teworis, revòlt, embargos, zak otorite sivil
   oswa militè, dife, inondasyon ,. aksidan, grèv oswa mank fasilite transpò,
   gaz, enèji, travay oswa materyèl.
 </p>
 <p>
-  <strong>6.5 Kesyon, Plent, Reklamasyon.</strong> Si ou gen nenpòt kesyon,
+  <strong>14.5 Kesyon, Plent, Reklamasyon.</strong> Si ou gen nenpòt kesyon,
   plent oswa reklamasyon ki gen rapò ak Aplikasyon an, tanpri kontakte nou nan:
   <a href="mailto:support@pathcheck.org"><span class="underline">support@pathcheck.org</span></a>.
 </p>
 <p>
-  <strong>6.6 Eksklizif Venue.</strong> Nan mezi pati yo gen pèmisyon dapre Akò
+  <strong>14.6 Eksklizif Venue.</strong> Nan mezi pati yo gen pèmisyon dapre Akò
   sa a pou kòmanse yon litij nan yon tribinal, tou de ou menm ak PCI dakò ke
   tout reklamasyon ak diskisyon ki rive soti nan oswa ki gen rapò ak sa a Akò
   pral plede sèlman nan tribinal yo leta oswa federal ki sitiye nan Boston,
   Massachusetts.
 </p>
 <p>
-  <strong>6.7 Lwa sou Gouvènman</strong> TÈM YO AK NENPT AKSYON KI KI TE RELIJE
+  <strong>14.7 Lwa sou Gouvènman</strong> TÈM YO AK NENPT AKSYON KI KI TE RELIJE
   A ANREJE AK INTERPRETE PA AK LWA NAN LWA COMMONWEALTH OF MASSACHUSETTS, ki
   konsistan avèk Lwa sou Arbitraj FEDERAL, san bay efè sou nenpòt prensip ki bay
   APLIKASYON LWA POU YON LDT JURISDIKSYON. KONVANSYON Nasyonzini an sou KONTRA
   POU VANN entènasyonal la nan machandiz pa aplike pou akò sa a.
 </p>
 <p>
-  <strong>6.8 Chwa langaj.</strong> Li se vle eksprime pati yo ke Akò sa a ak
+  <strong>14.8 Chwa langaj.</strong> Li se vle eksprime pati yo ke Akò sa a ak
   tout dokiman ki gen rapò ak yo te trase moute nan lang angle.
 </p>
 <p>
-  <strong>6.9 Avi.</strong> Ou ka remèt yon avi bay PCI nan adrès sa a: Path
+  <strong>14.9 Avi.</strong> Ou ka remèt yon avi bay PCI nan adrès sa a: Path
   Check, Inc. PO Box 441621, Somerville MA 02144. Yo dwe konsidere yon avi konsa
   lè yo resevwa pa PCI pa yon lèt bay pa sèvis livrezon lannwit ke yo rekonèt
   nasyonalman oswa lapòs premye pòs klas pre-peye nan nan adrès ki pi wo a.
 </p>
 <p>
-  <strong>6.10 Renonsyasyon.</strong> Nenpòt egzanpsyon oswa echèk nan ranfòse
+  <strong>14.10 Renonsyasyon.</strong> Nenpòt egzanpsyon oswa echèk nan ranfòse
   nenpòt dispozisyon nan kontra sa-a nan yon sèl okazyon pa pral jije yon
   egzansyon nan nenpòt ki lòt pwovizyon oswa nan dispozisyon sa a sou nenpòt ki
   lòt okazyon.
 </p>
 <p>
-  <strong>6.11 Divisibilite</strong>. Si nenpòt pòsyon nan Kontra sa-a se fèt
+  <strong>14.11 Divisibilite</strong>. Si nenpòt pòsyon nan Kontra sa-a se fèt
   valab oswa ki pa aplikab, yo dwe entèprete pòsyon sa a nan yon fason yo
   reflete, kòm prèske ke posib, entansyon orijinal la nan pati yo, ak pòsyon ki
   rete yo ap rete nan tout fòs ak efè.
 </p>
 <p>
-  <strong>6.12 Ekspòtasyon kontwòl.</strong> Ou pa ka itilize, ekspòtasyon,
+  <strong>14.12 Ekspòtasyon kontwòl.</strong> Ou pa ka itilize, ekspòtasyon,
   enpòte, oswa transfere Aplikasyon an eksepte jan otorize pa lalwa Etazini, lwa
   yo nan jiridiksyon an nan ki ou te jwenn Pwopriyete PCI, ak nenpòt lòt lwa ki
   aplikab yo. An patikilye, men san limit, Aplikasyon an pa ka ekspòte oswa
@@ -663,7 +663,7 @@ export default `
   règleman sa yo.
 </p>
 <p>
-  <strong>6.13 Jwenn aksè ak telechaje aplikasyon an soti nan iTunes.</strong>
+  <strong>14.13 Jwenn aksè ak telechaje aplikasyon an soti nan iTunes.</strong>
   Sa ki annapre yo aplike a nenpòt ki App Store Sourcing Aplikasyon jwenn aksè a
   oswa telechaje soti nan Apple App Store:
 </p>
@@ -752,14 +752,14 @@ export default `
   </li>
 </ol>
 <p>
-  <strong>6.14 Plent Konsomatè.</strong> An akò avèk Kòd Sivil Kalifòni §1789.3,
+  <strong>14.14 Plent Konsomatè.</strong> An akò avèk Kòd Sivil Kalifòni §1789.3,
   ou ka rapòte plent bay Inite a Asistans Plent nan Divizyon Sèvis pou Konsomatè
   nan Depatman Kalifòni nan Zafè Konsomatè nan Kalifòni lè w kontakte yo alekri
   nan 1625 North Market Blvd., Suite N 112, Sacramento, CA 95834, oswa pa
   telefòn nan (800) 952-5210.
 </p>
 <p>
-  <strong>6.15 Tout Akò.</strong> Akò sa a se akò final, konplè ak eksklizif de
+  <strong>14.15 Tout Akò.</strong> Akò sa a se akò final, konplè ak eksklizif de
   pati yo ki gen rapò ak matyè a nan sa a ak ranplase ak melanje tout diskisyon
   anvan ant pati yo ki gen rapò ak matyè sa yo.
 </p>


### PR DESCRIPTION
<!-- ## Description -->

Fixed the numbering so it didn't restart halfway through counting, removed the list nesting in the English EULA, and cleaned up both files a bit.

#### Linked issues:

None that I'm aware of.

#### Screenshots:

![Screenshot from 2020-04-24 05-55-17](https://user-images.githubusercontent.com/6233577/80205429-38cfa900-85f0-11ea-86c2-e321eab5ae78.png)

#### How to test

I don't think much testing is necessary since I just changed the HTML strings, but a visual scan to make sure there aren't any weird display problems in the HTML would be good