### PR TITLE
Background covers to edge of screen on iOS

### DIFF
--- a/app/components/NavigationBarWrapper.js
+++ b/app/components/NavigationBarWrapper.js
@@ -47,18 +47,17 @@ const NavigationBarWrapper = ({ children, title, onBackPress }) => {
 
 const themeNavBar = ({ theme }) => theme.navBar || Colors.VIOLET;
 
-// TODO: this breaks transitions...
-// const themeBackground = ({ theme }) =>
-//   theme.background || Colors.INTRO_WHITE_BG;
-
 const TopContainer = styled.SafeAreaView`
   flex: 0;
   background-color: ${themeNavBar};
 `;
 
+const themeBackground = ({ theme }) =>
+  theme.background || Colors.INTRO_WHITE_BG;
+
 const BottomContainer = styled.SafeAreaView`
   flex: 1;
-  background-color: ${Colors.INTRO_WHITE_BG};
+  background-color: ${themeBackground};
 `;
 
 const themeNavBarBorder = ({ theme }) =>

--- a/app/constants/colors.js
+++ b/app/constants/colors.js
@@ -8,7 +8,7 @@ const colors = {
   PRIMARY_TEXT: '#000',
   SUCCESS: '#41dca4', // Green
   WARNING: '#ffc000', // Orange
-  VIOLET_ALPHA_06: 'rgba(105, 121, 248, 0.06)',
+  VIOLET_ALPHA_06: '#f7f8ff', // cannot use transparency
   VIOLET: '#4051DB',
   TRANSPARENT: 'transparent',
 


### PR DESCRIPTION
Fixes the white background at edges of screen on the exposure history screen

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->

#### Screenshots:

Before:
<img width="487" alt="Screen Shot 2020-04-24 at 5 50 01 PM" src="https://user-images.githubusercontent.com/702990/80267063-166f7700-8654-11ea-90a7-bff30bde5465.png">

<img width="487" alt="Screen Shot 2020-04-24 at 5 45 13 PM" src="https://user-images.githubusercontent.com/702990/80267001-c0023880-8653-11ea-9546-0ccd5057d823.png">

After:
<img width="487" alt="Screen Shot 2020-04-24 at 5 50 16 PM" src="https://user-images.githubusercontent.com/702990/80267069-1b342b00-8654-11ea-9f7f-3f793bb2f58a.png">

<img width="487" alt="Screen Shot 2020-04-24 at 5 42 10 PM" src="https://user-images.githubusercontent.com/702990/80267003-c8f30a00-8653-11ea-9627-fb81ad74177f.png">


#### How to test

<!-- Description of how to validate or test this PR -->
