### PR TITLE
Add darkened background on Mayo Clinic link

### DIFF
--- a/app/views/LocationTracking.js
+++ b/app/views/LocationTracking.js
@@ -11,6 +11,7 @@ import {
   StatusBar,
   StyleSheet,
   Text,
+  TouchableHighlight,
   TouchableOpacity,
   View,
 } from 'react-native';
@@ -461,25 +462,24 @@ class LocationTracking extends Component {
 
         {/* eslint-disable-next-line react-native/no-color-literals */}
         <SafeAreaView style={{ backgroundColor: 'rgba(0, 0, 0, .07)' }}>
-          <TouchableOpacity
+          <TouchableHighlight
             onPress={this.getMayoInfoPressed.bind(this)}
-            style={styles.mayoInfoRow}>
-            <View style={styles.mayoInfoContainer}>
-              <Typography
-                style={styles.mainMayoHeader}
-                onPress={() => Linking.openURL(MAYO_COVID_URL)}>
-                {languages.t('label.home_mayo_link_heading')}
-              </Typography>
-              <Typography
-                style={styles.mainMayoSubtext}
-                onPress={() => Linking.openURL(MAYO_COVID_URL)}>
-                {languages.t('label.home_mayo_link_label')}
-              </Typography>
+            style={styles.mayoInfoRow}
+            underlayColor='rgba(0, 0, 0, .1)'>
+            <View style={{ flexDirection: 'row', flex: 1 }}>
+              <View style={styles.mayoInfoContainer}>
+                <Typography style={styles.mainMayoHeader}>
+                  {languages.t('label.home_mayo_link_heading')}
+                </Typography>
+                <Typography style={styles.mainMayoSubtext}>
+                  {languages.t('label.home_mayo_link_label')}
+                </Typography>
+              </View>
+              <View style={styles.arrowContainer}>
+                <Image source={foreArrow} style={this.arrow} />
+              </View>
             </View>
-            <View style={styles.arrowContainer}>
-              <Image source={foreArrow} style={this.arrow} />
-            </View>
-          </TouchableOpacity>
+          </TouchableHighlight>
         </SafeAreaView>
         {this.getSettings()}
       </ImageBackground>
@@ -582,15 +582,14 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     alignContent: 'flex-end',
     padding: 20,
+    flex: 1,
   },
   mainMayoHeader: {
-    textAlign: 'left',
     color: Colors.MISCHKA,
     fontSize: 18,
-    fontFamily: fontFamily.primaryBold,
+    fontFamily: fontFamily.primaryMedium,
   },
   mainMayoSubtext: {
-    textAlign: 'left',
     color: Colors.MISCHKA,
     fontSize: 18,
     fontFamily: fontFamily.primaryRegular,

--- a/app/views/LocationTracking.js
+++ b/app/views/LocationTracking.js
@@ -27,7 +27,7 @@ import BackgroundImageAtRisk from './../assets/images/backgroundAtRisk.png';
 import exportImage from './../assets/images/export.png';
 import foreArrow from './../assets/images/foreArrow.png';
 import BackgroundImage from './../assets/images/launchScreenBackground.png';
-import settingsIcon from './../assets/svgs/settingsIcon';
+import SettingsGear from './../assets/svgs/settingsGear';
 import StateAtRisk from './../assets/svgs/stateAtRisk';
 import StateNoContact from './../assets/svgs/stateNoContact';
 import StateUnknown from './../assets/svgs/stateUnknown';
@@ -305,10 +305,9 @@ class LocationTracking extends Component {
         <Image resizeMode={'contain'} />
         <SvgXml
           style={styles.stateIcon}
-          xml={settingsIcon}
+          xml={SettingsGear}
           width={32}
           height={32}
-          color='white'
         />
       </TouchableOpacity>
     );

--- a/app/views/LocationTracking.js
+++ b/app/views/LocationTracking.js
@@ -7,6 +7,7 @@ import {
   Image,
   ImageBackground,
   Linking,
+  SafeAreaView,
   StatusBar,
   StyleSheet,
   Text,
@@ -26,7 +27,7 @@ import BackgroundImageAtRisk from './../assets/images/backgroundAtRisk.png';
 import exportImage from './../assets/images/export.png';
 import foreArrow from './../assets/images/foreArrow.png';
 import BackgroundImage from './../assets/images/launchScreenBackground.png';
-import SettingsGear from './../assets/svgs/settingsGear';
+import settingsIcon from './../assets/svgs/settingsIcon';
 import StateAtRisk from './../assets/svgs/stateAtRisk';
 import StateNoContact from './../assets/svgs/stateNoContact';
 import StateUnknown from './../assets/svgs/stateUnknown';
@@ -304,9 +305,10 @@ class LocationTracking extends Component {
         <Image resizeMode={'contain'} />
         <SvgXml
           style={styles.stateIcon}
-          xml={SettingsGear}
+          xml={settingsIcon}
           width={32}
           height={32}
+          color='white'
         />
       </TouchableOpacity>
     );
@@ -440,7 +442,6 @@ class LocationTracking extends Component {
           translucent
         />
         {this.getPulseIfNeeded()}
-
         <View style={styles.mainContainer}>
           <View style={styles.contentAbovePulse}>
             {this.state.currentState === StateEnum.AT_RISK &&
@@ -459,7 +460,8 @@ class LocationTracking extends Component {
           </View>
         </View>
 
-        <View>
+        {/* eslint-disable-next-line react-native/no-color-literals */}
+        <SafeAreaView style={{ backgroundColor: 'rgba(0, 0, 0, .07)' }}>
           <TouchableOpacity
             onPress={this.getMayoInfoPressed.bind(this)}
             style={styles.mayoInfoRow}>
@@ -479,7 +481,7 @@ class LocationTracking extends Component {
               <Image source={foreArrow} style={this.arrow} />
             </View>
           </TouchableOpacity>
-        </View>
+        </SafeAreaView>
         {this.getSettings()}
       </ImageBackground>
     );


### PR DESCRIPTION
- Makes it much more clear where the touchable part is
- Prevents it from being in the "unsafe bezel area" on later model iPhone models.
- Removes the `onPress` for each inner text element, so that the entire "button" area highlights when touched.

#### Linked issues:

None

#### Screenshots:

<img width="487" alt="Screen Shot 2020-04-25 at 9 10 21 PM" src="https://user-images.githubusercontent.com/702990/80297654-f74b1500-8739-11ea-9044-de2ccbf86c82.png">
<img width="429" alt="Screen Shot 2020-04-25 at 9 11 27 PM" src="https://user-images.githubusercontent.com/702990/80297656-fb773280-8739-11ea-8336-89a2acc1837d.png">
<img width="504" alt="Screen Shot 2020-04-25 at 9 13 43 PM" src="https://user-images.githubusercontent.com/702990/80297658-fc0fc900-8739-11ea-8b3e-1c436bc35d77.png">


#### How to test


