### PR TITLE
Fix Android NavigationBarWrapper display jump bug (seen when exiting Settings screen)

### DIFF
--- a/app/components/NavigationBarWrapper.js
+++ b/app/components/NavigationBarWrapper.js
@@ -28,8 +28,8 @@ const NavigationBarWrapper = ({ children, title, onBackPress }) => {
     <>
       <StatusBar
         barStyle='light-content'
-        backgroundColor={barColor}
-        translucent={isPlatformiOS()}
+        backgroundColor={isPlatformiOS() ? barColor : 'transparent'}
+        translucent
       />
       <TopContainer />
       <BottomContainer>
@@ -63,12 +63,21 @@ const BottomContainer = styled.SafeAreaView`
 const themeNavBarBorder = ({ theme }) =>
   theme.navBarBorder || Colors.NAV_BAR_VIOLET;
 
-const Header = styled.View`
-  background-color: ${themeNavBar};
-  border-bottom-color: ${themeNavBarBorder};
-  border-bottom-width: 1px;
-  flex-direction: row;
-`;
+// Add header padding on Android
+const Header = isPlatformiOS()
+  ? styled.View`
+      background-color: ${themeNavBar};
+      border-bottom-color: ${themeNavBarBorder};
+      border-bottom-width: 1px;
+      flex-direction: row;
+    `
+  : styled.View`
+      background-color: ${themeNavBar};
+      border-bottom-color: ${themeNavBarBorder};
+      border-bottom-width: 1px;
+      padding-top: 10px;
+      flex-direction: row;
+    `;
 
 const Title = styled.Text`
   align-self: center;


### PR DESCRIPTION
## Description

As the title says, this PR is fixing a small display bug where exiting the Settings screen caused the display to jump noticeably. It was caused by the StatusBar translucent property being iOS specific for some reason. Fixed by making the status bar consistently take the same amount of space, then added some extra padding to NavigationBarWrapper to make up for the loss on Android.

#### Screenshots:

Android with padding:
![Screenshot from 2020-04-26 07-21-54](https://user-images.githubusercontent.com/6233577/80307600-a960fc00-878f-11ea-94da-5f77a255428e.png)

#### How to test

Please take a look to make sure this acts as expected on high res Android devices and devices with notches.

It shouldn't affect iOS display at all, but a double check would be great.
