### PR TITLE
Fallback to English translations in e2e tests

### DIFF
--- a/e2e/helpers/language.js
+++ b/e2e/helpers/language.js
@@ -1,4 +1,4 @@
-import assign from 'lodash/assign';
+import merge from 'lodash/merge';
 
 import * as english from '../../app/locales/en.json';
 import * as haitian from '../../app/locales/ht.json';
@@ -9,7 +9,7 @@ import * as haitian from '../../app/locales/ht.json';
  */
 const languageStrings = {
   'en-US': english,
-  'ht-HT': assign({}, english, haitian),
+  'ht-HT': merge({}, english, haitian),
 };
 
 export const languages = Object.keys(languageStrings).map(locale => [

--- a/e2e/helpers/language.js
+++ b/e2e/helpers/language.js
@@ -1,9 +1,15 @@
+import assign from 'lodash/assign';
+
 import * as english from '../../app/locales/en.json';
 import * as haitian from '../../app/locales/ht.json';
 
+/**
+ * Language strings for each locale. Strings are merged with english as a base
+ * to emulate i18next's english fallback in the case of missing locale strings.
+ */
 const languageStrings = {
   'en-US': english,
-  'ht-HT': haitian,
+  'ht-HT': assign({}, english, haitian),
 };
 
 export const languages = Object.keys(languageStrings).map(locale => [

--- a/e2e/helpers/language.js
+++ b/e2e/helpers/language.js
@@ -3,16 +3,15 @@ import merge from 'lodash/merge';
 import * as english from '../../app/locales/en.json';
 import * as haitian from '../../app/locales/ht.json';
 
-/**
- * Language strings for each locale. Strings are merged with english as a base
- * to emulate i18next's english fallback in the case of missing locale strings.
- */
 const languageStrings = {
   'en-US': english,
-  'ht-HT': merge({}, english, haitian),
+  'ht-HT': haitian,
 };
 
-export const languages = Object.keys(languageStrings).map(locale => [
-  locale,
-  languageStrings[locale],
-]);
+export const languages = Object.entries(languageStrings).map(
+  ([locale, strings]) => [
+    locale,
+    // fall back to english if not found in the locale strings
+    merge({}, english, strings),
+  ],
+);

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "emotion-theming": "^10.0.27",
     "i18next": "^19.3.3",
     "js-yaml": "^3.13.1",
+    "lodash": "^4.17.15",
     "patch-package": "^6.2.2",
     "pluralize": "^8.0.0",
     "postinstall-postinstall": "^2.0.0",


### PR DESCRIPTION
Fixes e2e when there are test on new strings. It will fall back to English for any missing keys, which matches the i18n lib's functionality

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->

#### Screenshots:

<!-- If you're changing visuals, add a screenshot here -->

#### How to test

e2e should pass
