### PR TITLE
Add ja and fil languages

### DIFF
--- a/app/locales/ar.json
+++ b/app/locales/ar.json
@@ -1,4 +1,5 @@
 {
+  "_display_name": "العربية",
   "label": {
     "about_title": "نبذة عنا",
     "authorities_add_button_label": "إضافة هيئة صحية موثوقة",

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -1,4 +1,5 @@
 {
+  "_display_name": "English",
   "about": {
     "dimensions": "Dimensions:",
     "operating_system_abbr": "OS:",

--- a/app/locales/es.json
+++ b/app/locales/es.json
@@ -1,4 +1,5 @@
 {
+  "_display_name": "Español",
   "history": {
     "no_exposure": "No ha habido contacto",
     "possible_exposure": "Posible",

--- a/app/locales/fil.json
+++ b/app/locales/fil.json
@@ -1,4 +1,5 @@
 {
+  "_display_name": "Filipino",
   "import": {
     "title": "Mag-import ng lokasyon"
   },

--- a/app/locales/fr.json
+++ b/app/locales/fr.json
@@ -1,4 +1,5 @@
 {
+  "_display_name": "Français",
   "import": {
     "button_text": "Importer les positions passées",
     "google": {

--- a/app/locales/ht.json
+++ b/app/locales/ht.json
@@ -1,4 +1,5 @@
 {
+  "_display_name": "Kreyòl ayisyen",
   "history": {
     "no_exposure": "Pa gen kontak",
     "possible_exposure": "Posib",

--- a/app/locales/id.json
+++ b/app/locales/id.json
@@ -1,4 +1,5 @@
 {
+  "_display_name": "Indonesia",
   "history": {
     "no_exposure": "Tidak ada paparan",
     "possible_exposure": "Kemungkinan Terpapar",

--- a/app/locales/it.json
+++ b/app/locales/it.json
@@ -1,4 +1,5 @@
 {
+  "_display_name": "Italiano",
   "history": {
     "no_exposure": "Non noto",
     "possible_exposure": "Possibile",

--- a/app/locales/ja.json
+++ b/app/locales/ja.json
@@ -1,4 +1,5 @@
 {
+  "_display_name": "日本語",
   "import": {
     "button_text": "過去の位置情報をインポートする",
     "google": {

--- a/app/locales/languages.js
+++ b/app/locales/languages.js
@@ -11,10 +11,12 @@ import { GetStoreData, SetStoreData } from '../helpers/General';
 import ar from './ar.json';
 import en from './en.json';
 import es from './es.json';
+import fil from './fil.json';
 import fr from './fr.json';
 import ht from './ht.json';
 import id from './id.json';
 import it from './it.json';
+import ja from './ja.json';
 import ml from './ml.json';
 import nl from './nl.json';
 import pl from './pl.json';
@@ -28,13 +30,9 @@ import zh_Hant from './zh_Hant.json';
 // Refer this for checking the codes and creating new folders https://developer.chrome.com/webstore/i18n
 
 // Adding/updating a language:
-// 1. Update i18next-parser.config.js to ensure the xy language is in "locales"
-// 2. run: npm run i18n:extract
-// 3. All known/new keys will be added into xy.json
-//    - any removed keys will be put into xy_old.json, do not commit this file
-// 4. Update translations as needed
-// 5. REMOVE all empty translations. e.g. "key": "", this will allow fallback to the default: English
-// 6. import xyIndex from `./xy.json` and add the language to the block at the bottom
+// 1. Add the language in Lokalise
+// 2. run: yarn i18n:pull with your lokalise token, see app/locales/pull.sh instructions
+// 3. import xy from `./xy.json` and add the language to the language block
 
 /** Fetch the user language override, if any */
 export async function getUserLocaleOverride() {
@@ -70,23 +68,26 @@ export async function setUserLocaleOverride(locale) {
   await SetStoreData(LANG_OVERRIDE, locale);
 }
 
+/* eslint-disable no-underscore-dangle */
 /** Languages only available in dev builds. */
 const DEV_LANGUAGES = __DEV__
   ? {
-      ar: { label: 'العربية', translation: ar },
-      es: { label: 'Español', translation: es },
-      fr: { label: 'Français', translation: fr },
-      id: { label: 'Indonesia', translation: id },
-      it: { label: 'Italiano', translation: it },
-      ml: { label: 'മലയാളം', translation: ml },
-      nl: { label: 'Nederlands', translation: nl },
-      pl: { label: 'Polski', translation: pl },
-      pt_BR: { label: 'Portugues do Brasil', translation: pt_BR },
-      ro: { label: 'Română', translation: ro },
-      ru: { label: 'Русский', translation: ru },
-      sk: { label: 'Slovak', translation: sk },
-      vi: { label: 'Vietnamese', translation: vi },
-      zh_Hant: { label: '繁體中文', translation: zh_Hant },
+      ar: { label: ar._display_name, translation: ar },
+      es: { label: es._display_name, translation: es },
+      fil: { label: fil._display_name, translation: fil },
+      fr: { label: fr._display_name, translation: fr },
+      id: { label: id._display_name, translation: id },
+      it: { label: it._display_name, translation: it },
+      ja: { label: ja._display_name, translation: ja },
+      ml: { label: ml._display_name, translation: ml },
+      nl: { label: nl._display_name, translation: nl },
+      pl: { label: pl._display_name, translation: pl },
+      pt_BR: { label: pt_BR._display_name, translation: pt_BR },
+      ro: { label: ro._display_name, translation: ro },
+      ru: { label: ru._display_name, translation: ru },
+      sk: { label: sk._display_name, translation: sk },
+      vi: { label: vi._display_name, translation: vi },
+      zh_Hant: { label: zh_Hant._display_name, translation: zh_Hant },
     }
   : {};
 
@@ -99,11 +100,12 @@ i18next.use(initReactI18next).init({
   fallbackLng: 'en', // If language detector fails
   returnEmptyString: false,
   resources: {
-    en: { label: 'English', translation: en },
-    ht: { label: 'Kreyòl ayisyen', translation: ht },
+    en: { label: en._display_name, translation: en },
+    ht: { label: ht._display_name, translation: ht },
     ...DEV_LANGUAGES,
   },
 });
+/* eslint-enable no-underscore-dangle */
 
 /** The known locale list */
 export const LOCALE_LIST = Object.entries(i18next.options.resources)
@@ -152,3 +154,6 @@ setLocale(supportedDeviceLanguageOrEnglish());
 getUserLocaleOverride().then(locale => locale && setLocale(locale));
 
 export default i18next;
+
+// do not remove, this will force the yarn i18n:extract to export this key
+i18next.t('_display_name');

--- a/app/locales/ml.json
+++ b/app/locales/ml.json
@@ -1,4 +1,5 @@
 {
+  "_display_name": "മലയാളം",
   "history": {
     "no_exposure": "സാധ്യതയില്ല",
     "possible_exposure": "സാധ്യത",

--- a/app/locales/nl.json
+++ b/app/locales/nl.json
@@ -1,4 +1,5 @@
 {
+  "_display_name": "Nederlands",
   "history": {
     "no_exposure": "Geen blootstelling",
     "possible_exposure": "Mogelijk",

--- a/app/locales/pl.json
+++ b/app/locales/pl.json
@@ -1,4 +1,5 @@
 {
+  "_display_name": "Polski",
   "label": {
     "about_title": "O",
     "authorities_add_button_label": "Dodaj zaufane źródło",

--- a/app/locales/pt_BR.json
+++ b/app/locales/pt_BR.json
@@ -1,4 +1,5 @@
 {
+  "_display_name": "Portugues do Brasil",
   "history": {
     "no_exposure": "Sem exposição conhecida",
     "possible_exposure": "Exposição possível",

--- a/app/locales/ro.json
+++ b/app/locales/ro.json
@@ -1,4 +1,5 @@
 {
+  "_display_name": "Română",
   "history": {
     "no_exposure": "Totul ok",
     "possible_exposure": "Expunere posibilă",

--- a/app/locales/ru.json
+++ b/app/locales/ru.json
@@ -1,4 +1,5 @@
 {
+  "_display_name": "Русский",
   "history": {
     "no_exposure": "Неизвестно",
     "possible_exposure": "Возможно",

--- a/app/locales/sk.json
+++ b/app/locales/sk.json
@@ -1,4 +1,5 @@
 {
+  "_display_name": "Slovak",
   "history": {
     "no_exposure": "Žiadne vystavenie sa riziku",
     "possible_exposure": "Možné vystavenie sa riziku",

--- a/app/locales/vi.json
+++ b/app/locales/vi.json
@@ -1,4 +1,5 @@
 {
+  "_display_name": "Tiếng Việt",
   "import": {
     "button_text": "Nhập lịch sử di chuyển trước đây",
     "google": {

--- a/app/locales/zh_Hant.json
+++ b/app/locales/zh_Hant.json
@@ -1,4 +1,5 @@
 {
+  "_display_name": "繁體中文",
   "import": {
     "button_text": "過去の位置情報をインポートする",
     "google": {


### PR DESCRIPTION
- Adds Japanese and Filipino which were exported from Lokalise.
- Exports the display name to be managed in lokalise.

#### Linked issues:

NA

#### Screenshots:

<img width="454" alt="Screen Shot 2020-04-27 at 6 00 29 PM" src="https://user-images.githubusercontent.com/702990/80435424-51221b00-88b1-11ea-9a1d-4a40ecb9664d.png">


#### How to test

<!-- Description of how to validate or test this PR -->
