### PR TITLE
Fix incorrect news from health authority in Latest News

### DIFF
--- a/app/views/News.js
+++ b/app/views/News.js
@@ -33,7 +33,7 @@ class NewsScreen extends Component {
     this.state = {
       visible: true,
       default_news: default_news,
-      newsUrls: [default_news, default_news],
+      newsUrls: [],
       current_page: 0,
     };
   }


### PR DESCRIPTION
## Description

Fixes a condition where the news url specified by an authority will not be shown on "Latest News", and instead the default Safe Paths news will be shown. 

The issue is that the React Native Webview seems to have issues if the uri is set on webview, and then the webview uri is updated very shortly thereafter (probably before rendering completes).  We currently try to set the default news in the news components constructor, and then we quickly update the url of the same webview after the storage retrieval for AUTHORITY_NEWS completes.  This causes the race condition and is definitely an issue on Android. I couldn't make it happen on iOS, but can't rule it out either.  

The fix is very small ... to remove the setting of the default_news url's on the news component's constructor.  The initial render has no news to show (so no webviews created), but once the callback from the AUTHORITY_NEWS storage completes, the setting of the component state triggers a re-render, this time with the news_url populated correct.  And yes, this will work (and I tested) when the app is first installed and no AUTHORITY_NEWS url's have been set.

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->
https://pathcheck.atlassian.net/browse/SAF-97


#### How to test

Set your health authority to "Mairie de PAP/Tabarre/PV/Delmas/CH".  Go back and load the latest news.  Prior to the fix you'll probably get the default Safe Paths news (esp on Android).  After the fix, you should see the correct news from the Haiti website (https://www.covidsource.org/).

**Note that you may need to wait a few seconds for the download and parse from the health authorty to complete.**