### PR TITLE
Fix e2e authority auto sub tests

### DIFF
--- a/e2e/onboarding/NoAuthSubscriptionPermission.spec.js
+++ b/e2e/onboarding/NoAuthSubscriptionPermission.spec.js
@@ -1,6 +1,7 @@
 /* eslint-disable jest/expect-expect */
 import { languages } from '../helpers/language';
 import { navigateThroughOnboarding } from '../helpers/onboarding';
+import Home from '../pages/Home.po.js';
 
 describe.each(languages)(
   `Healthcare Authority auto subscription in %s`,
@@ -16,9 +17,19 @@ describe.each(languages)(
       });
     });
 
-    it('Shows auto subscription as unset', async () => {
-      await navigateThroughOnboarding(languageStrings);
-      await device.takeScreenshot('No Auto Subscription');
+    describe('When skipping the auto subscribe step', () => {
+      beforeAll(async () => {
+        await navigateThroughOnboarding(languageStrings);
+      });
+
+      it('Shows auto subscribe as unset', async () => {
+        await Home.takeScreenshot();
+      });
+    });
+
+    afterAll(async () => {
+      await device.uninstallApp();
+      await device.installApp();
     });
   },
 );

--- a/e2e/pages/EnableAuthoritySubscription.po.js
+++ b/e2e/pages/EnableAuthoritySubscription.po.js
@@ -6,7 +6,7 @@ class EnableAuthoritySubscription {
   }
 
   async skipStep(languageStrings) {
-    await element(by.text(languageStrings.label.skip_this_step).tap());
+    await element(by.text(languageStrings.label.skip_this_step)).tap();
   }
 
   async takeScreenshot() {


### PR DESCRIPTION
Signed-off-by: Patrick Erichsen <patrick.a.erichsen@gmail.com>

 ## Description 

Fixes a broken e2e test that wasn't caught before merging due to the language string PR that wasn't merged until afterward.

#### How to test

Verify that all CI tests pass.
