### PR TITLE
Fix headline1 text cutoff

### DIFF
--- a/app/components/Typography.js
+++ b/app/components/Typography.js
@@ -79,7 +79,7 @@ const FONT_SIZE_MAP = {
 const getFontSize = ({ use = Type.Body1 }) => FONT_SIZE_MAP[use];
 
 const LINE_HEIGHT_MAP = {
-  [Type.Headline1]: '48px',
+  [Type.Headline1]: '52px',
   [Type.Headline2]: '34px',
   [Type.Headline3]: '40px',
   [Type.Body1]: '24px',

--- a/app/components/__tests__/__snapshots__/Typography.spec.js.snap
+++ b/app/components/__tests__/__snapshots__/Typography.spec.js.snap
@@ -88,7 +88,7 @@ exports[`headline1 is large and bold 1`] = `
         "fontFamily": "IBMPlexSans-Bold",
         "fontSize": 52,
         "fontWeight": "bold",
-        "lineHeight": 48,
+        "lineHeight": 52,
         "writingDirection": "ltr",
       }
     }

--- a/app/constants/__tests__/__snapshots__/Theme.spec.js.snap
+++ b/app/constants/__tests__/__snapshots__/Theme.spec.js.snap
@@ -67,7 +67,7 @@ exports[`includes extra background View if setBackground=true 1`] = `
           "fontFamily": "IBMPlexSans-Bold",
           "fontSize": 52,
           "fontWeight": "bold",
-          "lineHeight": 48,
+          "lineHeight": 52,
           "writingDirection": "ltr",
         }
       }


### PR DESCRIPTION
Fixes the janky headline cutoff

#### Linked issues:

<!-- Add issues here e.g.: Fixes #1234 -->

#### Screenshots:

Before:
<img width="314" alt="Screen Shot 2020-04-28 at 6 58 08 PM" src="https://user-images.githubusercontent.com/702990/80554500-3a97c480-8982-11ea-94d6-1824edefce14.png">

After:
<img width="317" alt="Screen Shot 2020-04-28 at 6 56 06 PM" src="https://user-images.githubusercontent.com/702990/80554504-3f5c7880-8982-11ea-9dd8-643559ab8cc5.png">


#### How to test

Do the thing.
