### PR TITLE
Remove global install of react-native-cli

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -226,13 +226,6 @@ if ! found_exe yarn; then
   echo "${GREEN}Yarn installed!${RESET}"
 fi
 
-if ! found_exe react-native; then
-  echo "${BLUE}Installing React Native tool...${RESET}"
-  yarn global add react-native-cli
-  yarn
-  echo "${GREEN}React Native tools installed!${RESET}"
-fi
-
 git config commit.template ./.gitmessage
 
 echo "${GREEN}You are now ready to go!${RESET}"


### PR DESCRIPTION
Signed-off-by: Patrick Erichsen <patrick.a.erichsen@gmail.com>

## Description

As per the [react-native-cli docs](https://github.com/react-native-community/cli#about), a global install of the CLI is unnecessary. It also isn't great practice to install things globally in the `dev_setup.sh` shell script that the user isn't totally aware of.

"react-native-cli – an optional global convenience package, which is a proxy to @react-native-community/cli and global installation helper. Please consider it legacy, because it's not necessary anymore."

#### How to test

Remove the package globally

```
yarn global remove react-native-cli
```

and run a sample `react-native-cli` command using `npx`, e.g.

```
npx react-native run-android
```