### PR TITLE
Put GPS filter behind dev flag

### DIFF
--- a/app/views/ChooseProvider.js
+++ b/app/views/ChooseProvider.js
@@ -42,7 +42,7 @@ class ChooseProviderScreen extends Component {
       urlEntryInProgress: false,
       urlText: '',
       authoritiesList: [],
-      isAuthorityFilterActive: true,
+      isAuthorityFilterActive: false,
       isAutoSubscribed: false,
     };
   }
@@ -60,7 +60,7 @@ class ChooseProviderScreen extends Component {
     BackHandler.addEventListener('hardwareBackPress', this.handleBackPress);
     await this.fetchAuthoritiesList(this.state.isAuthorityFilterActive);
     await this.fetchUserAuthorities();
-    await this.fetchAutoSubcribeStatus();
+    __DEV__ && (await this.fetchAutoSubcribeStatus());
   }
 
   componentWillUnmount() {
@@ -345,19 +345,21 @@ class ChooseProviderScreen extends Component {
             </TouchableOpacity>
           </MenuTrigger>
           <MenuOptions>
-            <TouchableOpacity
-              style={styles.authorityFilter}
-              onPress={() => this.toggleFilterAuthoritesByGPSHistory()}>
-              <Typography style={styles.authorityFilterText} use={'body2'}>
-                {languages.t('label.filter_authorities_by_gps_history')}
-              </Typography>
-              <Switch
-                onValueChange={val =>
-                  this.filterAuthoritesByGPSHistory({ val })
-                }
-                value={this.state.isAuthorityFilterActive}
-              />
-            </TouchableOpacity>
+            {__DEV__ && (
+              <TouchableOpacity
+                style={styles.authorityFilter}
+                onPress={() => this.toggleFilterAuthoritesByGPSHistory()}>
+                <Typography style={styles.authorityFilterText} use={'body2'}>
+                  {languages.t('label.filter_authorities_by_gps_history')}
+                </Typography>
+                <Switch
+                  onValueChange={val =>
+                    this.filterAuthoritesByGPSHistory({ val })
+                  }
+                  value={this.state.isAuthorityFilterActive}
+                />
+              </TouchableOpacity>
+            )}
             {this.state.authoritiesList === undefined
               ? null
               : this.state.authoritiesList.map(item => {


### PR DESCRIPTION
Signed-off-by: Patrick Erichsen <patrick.a.erichsen@gmail.com>

## Description

Puts the GPS filter on `ChooseProvider` behind a feature flag.

#### Screenshots:

<img width="417" alt="Screen Shot 2020-04-28 at 9 27 19 PM" src="https://user-images.githubusercontent.com/20157849/80555831-0da1dc80-8997-11ea-89f6-68dbe7a35137.png">

#### How to test

Open the `Settings` on an Android device and toggle the `JS Dev Mode` checkbox to set `__DEV__` to false.

Then, visit the `ChooseProvider` screen and confirm that it matches the screenshot above.