### PR TITLE
Fix postinstall script on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preinstall": "node -e \"if(process.env.npm_execpath.indexOf('yarn') === -1) throw new Error('You must use Yarn to install, not NPM')\"",
     "install:pod": "cd ios && bundle install && bundle exec pod install",
     "lint": "eslint ./",
-    "postinstall": "patch-package; npx react-native-jetifier",
+    "postinstall": "patch-package && npx react-native-jetifier",
     "postversion": "react-native-version",
     "format:all": "prettier --write ./app/**/*.js",
     "detox-setup": "detox clean-framework-cache && detox build-framework-cache",


### PR DESCRIPTION
<!-- ## Description -->

Changed the semicolon to && so postinstall works on Windows.

#### Linked issues:

Fixes #707 

#### How to test

Run yarn install in the terminal.
