### PR TITLE
Set up location after skipping the steps

### DIFF
--- a/app/views/onboarding/Onboarding5.js
+++ b/app/views/onboarding/Onboarding5.js
@@ -287,7 +287,10 @@ class Onboarding extends Component {
         this.requestHCASubscription();
         break;
       case StepEnum.DONE:
-        SetStoreData(PARTICIPATE, 'true');
+        SetStoreData(
+          PARTICIPATE,
+          this.state.locationPermission === PermissionStatusEnum.GRANTED,
+        );
         SetStoreData('ONBOARDING_DONE', true);
         this.props.navigation.replace('LocationTrackingScreen');
     }


### PR DESCRIPTION
<!-- ## Description -->

Fixed #719 issue


#### How to test

Steps to reproduce

- Launch App
- Tap on "Get Started"
- Accept the Licensing agreement
- Tap Next twice and click on "Set up my phone"
- Tap "Skip this step". Location access is shown in red cross mark
- Tap on "Finish Setup" to navigate to Home screen
- Navigate to Dashboard
