### PR TITLE
Update the upgrade version to 1.0.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -1,4 +1,4 @@
 # Versions less than specified will receive a gentle update notification (dismissable alert only)
-upgrade version: "0.9.5"
+upgrade version: "1.0.0"
 # Versions less than specified will receive a mandatory update notification (push + non-dismissable alert)
 mandatory upgrade version: "0.9.4"


### PR DESCRIPTION
## Description

This is a very small change to bring the versions.yaml file in sync with how we have it set in the master branch.  We need to be very careful on how we set this version, especially until https://pathcheck.atlassian.net/browse/SAF-143 is fixed, as we can very easily cause inadvertent forced upgrades if this gets set wrong (for example, currently setting to 0.9.5 will cause - incorrectly I might add -  a forced upgrade to kick in for all 1.x.x versions)!  I caught that issue at the last minute doing the version bump to v1.0.1 (I had to change directly in master to quickly fix the issue - not ideal!).

What this PR really does is just makes sure the next time we do a version bump, we won't accidentally cause forced upgrades for apps at v1.0.0 when we merge the diffs from develop to master.
