### PR TITLE
Remove rebasing from suggestions in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ git remote add upstream git@github.com:tripleblindmarket/covid-safe-paths.git
   
   git pull upstream/develop # make sure you have the latest code from upstream
   
-  git push origin develop # optional, push these changes to your fork's develop branch
+  git push origin develop # optional, push these changes to YOUR fork's develop branch
   ```
 2. Create the branch. Name the branch something to reflect what you are doing.
   ```
@@ -68,7 +68,8 @@ git remote add upstream git@github.com:tripleblindmarket/covid-safe-paths.git
 ```bash
 git fetch upstream # fetch latest branches from "COVID Safe Paths" repo
 
-git merge upstream/develop # merge latest develop code into your local branch, this will create a single merge commit
+# merge latest develop code into your local branch, this will always create a single merge commit
+git merge upstream/develop --no-ff
 
 # you may need to resolve conflicts. Once finished resolving conflicts:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,17 +39,15 @@ git remote add upstream git@github.com:tripleblindmarket/covid-safe-paths.git
 
 ### Create a branch 
 
-Always create a new branch based on the *latest* `upstream/develop`. Name the branch something to reflect what you are doing. For example, if you want to add a new icon, a branch name you could use:
-
-1. Get the latest `upstream/develop`:
+1. Always create a new branch from the latest `upstream/develop`:
 
   ```bash
-  git checkout develop # you want to branch from the main 'develop' branch
+  git checkout develop # you want to branch from the latest 'develop' branch
   
   git pull upstream/develop # make sure you have the latest code from upstream
   ```
 
-1. Create the branch
+1. Create the branch. Name the branch something to reflect what you are doing.
 
   ```
   git checkout -b "feature/new-icon" develop # new branch created!
@@ -105,6 +103,7 @@ git push -u origin
 
 - Provide a meaningful title and description to your PR, as shown in the above image.
 - Provide Issue ID on PR description to link/close the issue upon PR merged.
+- If you are changing visuals, please provide screenshots so the PR reviewer can see what you've done without running it in the app.
 
 ## Helpful resources on Git
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,7 @@ git remote add upstream git@github.com:tripleblindmarket/covid-safe-paths.git
 # if you've already done this it will fail, that's fine:
 git remote add upstream git@github.com:tripleblindmarket/covid-safe-paths.git
 
+# ensure you are on your feature/fix branch
 git checkout feature/my-feature
 
 # get latest upstream branches e.g. upstream/develop

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,15 +40,12 @@ git remote add upstream git@github.com:tripleblindmarket/covid-safe-paths.git
 ### Create a branch 
 
 1. Always create a new branch from the latest `upstream/develop`:
-
   ```bash
   git checkout develop # you want to branch from the latest 'develop' branch
   
   git pull upstream/develop # make sure you have the latest code from upstream
   ```
-
-1. Create the branch. Name the branch something to reflect what you are doing.
-
+2. Create the branch. Name the branch something to reflect what you are doing.
   ```
   git checkout -b "feature/new-icon" develop # new branch created!
   
@@ -60,10 +57,9 @@ git remote add upstream git@github.com:tripleblindmarket/covid-safe-paths.git
 
   git checkout -b "release/new-icon" develop # new branch created!
   ```
-
-1. Stick to the coding style and patterns that are used already.
-1. Document code! Comments are good. More comments are better. :)
-1. Make commits as you desire. Ultimately they will be squashed, so make notes to yourself. It's as simple as `git commit -m "commit message goes here"`!
+3. Stick to the coding style and patterns that are used already.
+4. Document code! Comments are good. More comments are better. :)
+5. Make commits as you desire. Ultimately they will be squashed, so make notes to yourself. It's as simple as `git commit -m "commit message goes here"`!
 
 ### Merge your feature branch with upstream/develop to get the latest changes.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,13 +23,13 @@ We welcome participation in an open project. We want to make it as easy as possi
 
 cd ~ # get to your home directory or where ever you want to go
 
-git clone https://github.com/YOURACCOUNT/covid-safe-paths
+git clone git@github.com:YOURACCOUNT/covid-safe-paths.git
 
 # change into the newly created directory
 cd covid-safe-paths
 
 # set upstream against COVID Safe Paths repository
-git remote add upstream https://github.com/tripleblindmarket/covid-safe-paths.git
+git remote add upstream git@github.com:tripleblindmarket/covid-safe-paths.git
 
 ```
 
@@ -37,57 +37,54 @@ git remote add upstream https://github.com/tripleblindmarket/covid-safe-paths.gi
 
 ## Make Changes
 
-1. Create a branch based on the `develop` branch on your forked repository. Name the branch something to reflect what you are doing. For example, if you want to add a new icon, a branch name you could use:
+### Create a branch 
+
+Always create a new branch based on the *latest* `upstream/develop`. Name the branch something to reflect what you are doing. For example, if you want to add a new icon, a branch name you could use:
+
+1. Get the latest `upstream/develop`:
+
+  ```bash
+  git checkout develop # you want to branch from the main 'develop' branch
+  
+  git pull upstream/develop # make sure you have the latest code from upstream
+  ```
+
+1. Create the branch
+
+  ```
+  git checkout -b "feature/new-icon" develop # new branch created!
+  
+  "or"
+  
+  git checkout -b "fix/new-icon" develop # new branch created!
+
+  "or"
+
+  git checkout -b "release/new-icon" develop # new branch created!
+  ```
+
+1. Stick to the coding style and patterns that are used already.
+1. Document code! Comments are good. More comments are better. :)
+1. Make commits as you desire. Ultimately they will be squashed, so make notes to yourself. It's as simple as `git commit -m "commit message goes here"`!
+
+### Merge your feature branch with upstream/develop to get the latest changes.
 
 ```bash
-git checkout develop # you want to branch from the main 'develop' branch
-
-git pull # make sure you have the latest code when you start the branch
-
-git checkout -b "feature/new-icon" develop # new branch created!
-
-"or"
-
-git checkout -b "fix/new-icon" develop # new branch created!
-
-"or"
-
-git checkout -b "release/new-icon" develop # new branch created!
-```
-
-2. Stick to the coding style and patterns that are used already.
-
-3. Document code! Comments are good. More comments are better. :)
-
-4. Make commits as you desire. Ultimately they will be squashed, so make
-
-notes to yourself. It's as simple as `git commit -m "commit message goes here"`!
-
-5. Rebase your feature branch with upstream/develop to avoid any code conflicts:
-
-```bash
-# 1. Rebase Base(COVID Safe Paths) repository with fork repository - develop branch
-
-git checkout develop # switch to base branch(local)
-
 git fetch upstream # fetch latest commits from "COVID Safe Paths" develop branch
 
-git rebase upstream/develop # rebase code against your forked develop branch(local)
+git merge upstream/develop # merge latest develop code into your local branch, this will create a single merge commit
 
-git push -f origin develop # push rebased code after resolving conflicts to forked develop branch(remote)
+# you may need to resolve conflicts. Once finished resolving conflicts:
 
-# 2. Rebase feature branch(local) with develop branch(local)
+git commit # this will pre-fill the commit message with details of the merge from develop
 
-git checkout <feature-branch-name-you-created> # switch back to original feature branch(local) you are working
-
-git rebase develop # now rebase your feature branch(local) against develop branch(local)
-
-git push origin feature/<your-feature-branch-name> # after resolving all conflicts, push your new feature branch to the remote forked repository
+# push your changes up to your branch
+git push -u origin
 
 # now your feature branch is ready for PR against COVID Safe Paths develop branch.
 ```
 
-6. Start a PR to submit your changes back to the original project:
+### Start a PR to submit your changes back to the original project:
 
 - Visit https://github.com/your-git-userid/covid-safe-paths/branches
 
@@ -110,22 +107,6 @@ git push origin feature/<your-feature-branch-name> # after resolving all conflic
 - Provide Issue ID on PR description to link/close the issue upon PR merged.
 
 ## Helpful resources on Git
-
-- Git commands:
-
-```
-git checkout develop
-
-git fetch
-
-git reset --hard origin/develop
-
-git checkout <your_branch_name>
-
-git rebase develop
-
-git push -f
-```
 
 - Documentation on how to [create a Pull Request (PR) on Github](https://help.github.com/articles/using-pull-requests/) for review and merging.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,19 +63,24 @@ git remote add upstream git@github.com:tripleblindmarket/covid-safe-paths.git
 4. Document code! Comments are good. More comments are better. :)
 5. Make commits as you desire. Ultimately they will be squashed, so make notes to yourself. It's as simple as `git commit -m "commit message goes here"`!
 
-### Merge your feature branch with upstream/develop to get the latest changes.
+### Merge upstream/develop into your branch to get the latest changes.
 
 ```bash
-git fetch upstream # fetch latest branches from "COVID Safe Paths" repo
+# if you've already done this it will fail, that's fine:
+git remote add upstream git@github.com:tripleblindmarket/covid-safe-paths.git
 
-# merge latest develop code into your local branch, this will always create a single merge commit
+git checkout feature/my-feature
+
+# get latest upstream branches e.g. upstream/develop
+git fetch upstream
+
+# merge upstream/develop into your local branch, this will always create a single merge commit
 git merge upstream/develop --no-ff
 
-# you may need to resolve conflicts. Once finished resolving conflicts:
+# you may need to resolve conflicts. If so, resolve them and commit the merge:
+git commit
 
-git commit # this will pre-fill the commit message with details of the merge from develop
-
-# push your changes up to your branch
+# push your changes up to your branch again
 git push -u origin
 
 # now your feature branch is ready for PR against COVID Safe Paths develop branch.
@@ -151,6 +156,8 @@ _Advanced users may install the `hub` gem and use the [`hub pull-request` comman
 - A team member will review the pull request, request change or approve and merge into the `develop` branch.
 
 ## Reviewing Pull Requests
+
+- If you are using VS Code, use the [GitHub PR extension](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github), which will allow you to checkout and run anyone's PR with ease.
 
 - Open the PR on Github. At the top of the PR page is a number which identifies it -123 and the name of the author's branch -branch-name. Copy down both of these.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,8 @@ git remote add upstream git@github.com:tripleblindmarket/covid-safe-paths.git
   git checkout develop # you want to branch from the latest 'develop' branch
   
   git pull upstream/develop # make sure you have the latest code from upstream
+  
+  git push origin develop # optional, push these changes to your fork's develop branch
   ```
 2. Create the branch. Name the branch something to reflect what you are doing.
   ```
@@ -64,7 +66,7 @@ git remote add upstream git@github.com:tripleblindmarket/covid-safe-paths.git
 ### Merge your feature branch with upstream/develop to get the latest changes.
 
 ```bash
-git fetch upstream # fetch latest commits from "COVID Safe Paths" develop branch
+git fetch upstream # fetch latest branches from "COVID Safe Paths" repo
 
 git merge upstream/develop # merge latest develop code into your local branch, this will create a single merge commit
 


### PR DESCRIPTION
Updates the contribution guide to **not suggest rebasing**

It's causing broken histories in many PRs, slowing down the time to review.

Suggesting merge directly from `upstream/develop` instead, which is cleaner and more up-to-date.
