### PR TITLE
Lokalise issue

### DIFF
--- a/ios/fr.lproj/InfoPlist.strings
+++ b/ios/fr.lproj/InfoPlist.strings
@@ -1,0 +1,3 @@
+"NSLocationAlwaysAndWhenInUseUsageDescription" = "[%key_id:42304622%]";
+"NSLocationAlwaysUsageDescription" = "[%key_id:42304623%]";
+"NSLocationWhenInUseUsageDescription" = "[%key_id:42304622%]";

--- a/ios/id.lproj/InfoPlist.strings
+++ b/ios/id.lproj/InfoPlist.strings
@@ -1,0 +1,3 @@
+"NSLocationAlwaysAndWhenInUseUsageDescription" = "[%key_id:42304622%]";
+"NSLocationAlwaysUsageDescription" = "[%key_id:42304623%]";
+"NSLocationWhenInUseUsageDescription" = "[%key_id:42304622%]";

--- a/ios/ro.lproj/InfoPlist.strings
+++ b/ios/ro.lproj/InfoPlist.strings
@@ -1,0 +1,3 @@
+"NSLocationAlwaysAndWhenInUseUsageDescription" = "[%key_id:42304622%]";
+"NSLocationAlwaysUsageDescription" = "[%key_id:42304623%]";
+"NSLocationWhenInUseUsageDescription" = "[%key_id:42304622%]";

--- a/ios/vi.lproj/InfoPlist.strings
+++ b/ios/vi.lproj/InfoPlist.strings
@@ -1,0 +1,3 @@
+"NSLocationAlwaysAndWhenInUseUsageDescription" = "[%key_id:42304622%]";
+"NSLocationAlwaysUsageDescription" = "[%key_id:42304623%]";
+"NSLocationWhenInUseUsageDescription" = "[%key_id:42304622%]";

--- a/ios/zh-Hant.lproj/InfoPlist.strings
+++ b/ios/zh-Hant.lproj/InfoPlist.strings
@@ -1,0 +1,3 @@
+"NSLocationAlwaysAndWhenInUseUsageDescription" = "[%key_id:42304622%]";
+"NSLocationAlwaysUsageDescription" = "[%key_id:42304623%]";
+"NSLocationWhenInUseUsageDescription" = "[%key_id:42304622%]";


### PR DESCRIPTION
Example of lokalise file download issue, uses this command:

```
echo "Downloading iOS *.strings"
lokalise2 file download \
  --add-newline-eof \
  --export-empty-as=skip \
  --format strings \
  --include-description \
  --original-filenames \
  --placeholder-format=ios \
  --unzip-to=ios \
  --export-sort=a_z \
  --config .lokalise.yml --token=$LOKALISE_TOKEN
```