### PR TITLE
Remove magic strings for naviagtion

### DIFF
--- a/app/Entry.js
+++ b/app/Entry.js
@@ -4,134 +4,161 @@ import {
   createStackNavigator,
 } from '@react-navigation/stack';
 import React, { Component } from 'react';
+import { StyleSheet } from 'react-native';
 
+import colors from './constants/colors';
 import { GetStoreData } from './helpers/General';
-import AboutScreen from './views/About';
-import ChooseProviderScreen from './views/ChooseProvider';
-import { ExportScreen } from './views/Export';
-import { ExposureHistoryScreen } from './views/ExposureHistory/ExposureHistory';
-import ImportScreen from './views/Import';
-import { LicensesScreen } from './views/Licenses';
-import LocationTracking from './views/LocationTracking';
-import NewsScreen from './views/News';
-import Onboarding1 from './views/onboarding/Onboarding1';
-import Onboarding2 from './views/onboarding/Onboarding2';
-import Onboarding3 from './views/onboarding/Onboarding3';
-import Onboarding4 from './views/onboarding/Onboarding4';
-import Onboarding5 from './views/onboarding/Onboarding5';
-import { SettingsScreen } from './views/Settings';
+import { ABOUT_SCREEN_NAME, AboutScreen } from './views/About';
+import {
+  CHOOSE_PROVIDER_SCREEN_NAME,
+  ChooseProviderScreen,
+} from './views/ChooseProvider';
+import { EXPORT_SCREEN_NAME, ExportScreen } from './views/Export';
+import {
+  EXPOSURE_HISTORY_SCREEN_NAME,
+  ExposureHistoryScreen,
+} from './views/ExposureHistory/ExposureHistory';
+import { IMPORT_SCREEN_NAME, ImportScreen } from './views/Import';
+import { LICENSES_SCREEN_NAME, LicensesScreen } from './views/Licenses';
+import {
+  LOCATION_TRACKING_SCREEN_NAME,
+  LocationTracking,
+} from './views/LocationTracking';
+import { NEWS_SCREEN_NAME, NewsScreen } from './views/News';
+import {
+  ONBOARDING1_SCREEN_NAME,
+  Onboarding1,
+} from './views/onboarding/Onboarding1';
+import {
+  ONBOARDING2_SCREEN_NAME,
+  Onboarding2,
+} from './views/onboarding/Onboarding2';
+import {
+  ONBOARDING3_SCREEN_NAME,
+  Onboarding3,
+} from './views/onboarding/Onboarding3';
+import {
+  ONBOARDING4_SCREEN_NAME,
+  Onboarding4,
+} from './views/onboarding/Onboarding4';
+import {
+  ONBOARDING5_SCREEN_NAME,
+  Onboarding5,
+} from './views/onboarding/Onboarding5';
+import { SETTINGS_SCREEN_NAME, SettingsScreen } from './views/Settings';
 
 const Stack = createStackNavigator();
+
+export const INITIAL_SCREEN_NAME = 'InitalScreen';
 
 class Entry extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      initialRouteName: '',
+      isOnboardingComplete: false,
     };
   }
 
-  componentDidMount() {
-    GetStoreData('ONBOARDING_DONE')
-      .then(onboardingDone => {
-        this.setState({
-          initialRouteName: onboardingDone,
-        });
-      })
-      .catch(error => console.log(error));
+  async componentDidMount() {
+    await this.getOnboardingStatus();
+  }
+
+  async getOnboardingStatus() {
+    const isOnboardingComplete = await GetStoreData(
+      'ONBOARDING_DONE',
+      false,
+    ).catch(error => console.log(error));
+
+    this.setState({
+      isOnboardingComplete,
+    });
+  }
+
+  getInitalComponent() {
+    return this.state.isOnboardingComplete ? LocationTracking : Onboarding1;
   }
 
   render() {
     return (
       <NavigationContainer>
         <Stack.Navigator
-          initialRouteName='InitialScreen'
+          initialRouteName={INITIAL_SCREEN_NAME}
           screenOptions={{
             cardStyleInterpolator: CardStyleInterpolators.forHorizontalIOS,
-            cardStyle: {
-              backgroundColor: 'transparent', // prevent white flash on Android
-            },
+            cardStyle: styles.cardStyle,
           }}>
-          {this.state.initialRouteName === 'true' ? (
-            <Stack.Screen
-              name='InitialScreen'
-              component={LocationTracking}
-              options={{ headerShown: false }}
-            />
-          ) : (
-            <Stack.Screen
-              name='InitialScreen'
-              component={Onboarding1}
-              options={{ headerShown: false }}
-            />
-          )}
           <Stack.Screen
-            name='Onboarding1'
+            name={INITIAL_SCREEN_NAME}
+            component={this.getInitalComponent()}
+            options={{ headerShown: false }}
+          />
+          <Stack.Screen
+            name={ONBOARDING1_SCREEN_NAME}
             component={Onboarding1}
             options={{ headerShown: false }}
           />
           <Stack.Screen
-            name='Onboarding2'
+            name={ONBOARDING2_SCREEN_NAME}
             component={Onboarding2}
             options={{ headerShown: false }}
           />
           <Stack.Screen
-            name='Onboarding3'
+            name={ONBOARDING3_SCREEN_NAME}
             component={Onboarding3}
             options={{ headerShown: false }}
           />
           <Stack.Screen
-            name='Onboarding4'
+            name={ONBOARDING4_SCREEN_NAME}
             component={Onboarding4}
             options={{ headerShown: false }}
           />
           <Stack.Screen
-            name='Onboarding5'
+            name={ONBOARDING5_SCREEN_NAME}
             component={Onboarding5}
             options={{ headerShown: false }}
           />
           <Stack.Screen
-            name='LocationTrackingScreen'
+            name={LOCATION_TRACKING_SCREEN_NAME}
             component={LocationTracking}
             options={{ headerShown: false }}
           />
           <Stack.Screen
-            name='NewsScreen'
+            name={NEWS_SCREEN_NAME}
             component={NewsScreen}
             options={{ headerShown: false }}
           />
           <Stack.Screen
-            name='ExportScreen'
+            name={EXPORT_SCREEN_NAME}
             component={ExportScreen}
             options={{ headerShown: false }}
           />
           <Stack.Screen
-            name='ImportScreen'
+            name={IMPORT_SCREEN_NAME}
             component={ImportScreen}
             options={{ headerShown: false }}
           />
           <Stack.Screen
-            name='SettingsScreen'
+            name={SETTINGS_SCREEN_NAME}
             component={SettingsScreen}
             options={{ headerShown: false }}
           />
           <Stack.Screen
-            name='ChooseProviderScreen'
+            name={CHOOSE_PROVIDER_SCREEN_NAME}
             component={ChooseProviderScreen}
             options={{ headerShown: false }}
           />
           <Stack.Screen
-            name='LicensesScreen'
+            name={LICENSES_SCREEN_NAME}
             component={LicensesScreen}
             options={{ headerShown: false }}
           />
           <Stack.Screen
-            name='ExposureHistoryScreen'
+            name={EXPOSURE_HISTORY_SCREEN_NAME}
             component={ExposureHistoryScreen}
             options={{ headerShown: false }}
           />
           <Stack.Screen
-            name='AboutScreen'
+            name={ABOUT_SCREEN_NAME}
             component={AboutScreen}
             options={{ headerShown: false }}
           />
@@ -140,5 +167,11 @@ class Entry extends Component {
     );
   }
 }
+
+const styles = StyleSheet.create({
+  cardStyle: {
+    backgroundColor: colors.TRANSPARENT, // prevent white flash on Android
+  },
+});
 
 export default Entry;

--- a/app/Entry.js
+++ b/app/Entry.js
@@ -22,28 +22,28 @@ import { IMPORT_SCREEN_NAME, ImportScreen } from './views/Import';
 import { LICENSES_SCREEN_NAME, LicensesScreen } from './views/Licenses';
 import {
   LOCATION_TRACKING_SCREEN_NAME,
-  LocationTracking,
+  LocationTrackingScreen,
 } from './views/LocationTracking';
 import { NEWS_SCREEN_NAME, NewsScreen } from './views/News';
 import {
   ONBOARDING1_SCREEN_NAME,
-  Onboarding1,
+  Onboarding1Screen,
 } from './views/onboarding/Onboarding1';
 import {
   ONBOARDING2_SCREEN_NAME,
-  Onboarding2,
+  Onboarding2Screen,
 } from './views/onboarding/Onboarding2';
 import {
   ONBOARDING3_SCREEN_NAME,
-  Onboarding3,
+  Onboarding3Screen,
 } from './views/onboarding/Onboarding3';
 import {
   ONBOARDING4_SCREEN_NAME,
-  Onboarding4,
+  Onboarding4Screen,
 } from './views/onboarding/Onboarding4';
 import {
   ONBOARDING5_SCREEN_NAME,
-  Onboarding5,
+  Onboarding5Screen,
 } from './views/onboarding/Onboarding5';
 import { SETTINGS_SCREEN_NAME, SettingsScreen } from './views/Settings';
 
@@ -75,7 +75,9 @@ class Entry extends Component {
   }
 
   getInitalComponent() {
-    return this.state.isOnboardingComplete ? LocationTracking : Onboarding1;
+    return this.state.isOnboardingComplete
+      ? LocationTrackingScreen
+      : Onboarding1Screen;
   }
 
   render() {
@@ -94,32 +96,32 @@ class Entry extends Component {
           />
           <Stack.Screen
             name={ONBOARDING1_SCREEN_NAME}
-            component={Onboarding1}
+            component={Onboarding1Screen}
             options={{ headerShown: false }}
           />
           <Stack.Screen
             name={ONBOARDING2_SCREEN_NAME}
-            component={Onboarding2}
+            component={Onboarding2Screen}
             options={{ headerShown: false }}
           />
           <Stack.Screen
             name={ONBOARDING3_SCREEN_NAME}
-            component={Onboarding3}
+            component={Onboarding3Screen}
             options={{ headerShown: false }}
           />
           <Stack.Screen
             name={ONBOARDING4_SCREEN_NAME}
-            component={Onboarding4}
+            component={Onboarding4Screen}
             options={{ headerShown: false }}
           />
           <Stack.Screen
             name={ONBOARDING5_SCREEN_NAME}
-            component={Onboarding5}
+            component={Onboarding5Screen}
             options={{ headerShown: false }}
           />
           <Stack.Screen
             name={LOCATION_TRACKING_SCREEN_NAME}
-            component={LocationTracking}
+            component={LocationTrackingScreen}
             options={{ headerShown: false }}
           />
           <Stack.Screen

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -26,13 +26,13 @@
       "instructions_second": "Before you can import, you must first \"Take out\" your location data from Google.",
       "title": "Google Maps",
       "visit_button_text": "Visit Google Takeout",
-      "already_imported":"Provided Takeout file has already been imported.",
+      "already_imported": "Provided Takeout file has already been imported.",
       "no_recent_locations": "Takeout doesn't have any recent locations.",
       "invalid_file_format": "Provided file format is not supported. \nSupported formats: \".zip\".",
       "file_open_error": "Could not open the file. \nPlease, make sure the file is opened from Google Drive"
     },
-    "success":"Recent locations has been successfully imported!",
-    "error":"Something went wrong while importing your data.",
+    "success": "Recent locations has been successfully imported!",
+    "error": "Something went wrong while importing your data.",
     "subtitle": "To see if you encountered someone with COVID-19 prior to downloading this app, you can import your personal location history.",
     "title": "Import Locations"
   },

--- a/app/services/LocationService.js
+++ b/app/services/LocationService.js
@@ -446,7 +446,7 @@ export default class LocationServices {
 
     isBackgroundGeolocationConfigured = false;
     SetStoreData(PARTICIPATE, 'false').then(() => {
-      // nav.navigate('LocationTrackingScreen', {});
+      // nav.navigate('LocationTracking', {});
     });
   }
 }

--- a/app/views/About.js
+++ b/app/views/About.js
@@ -139,7 +139,8 @@ export class AboutScreen extends Component {
                 {languages.t('about.version')}
               </Typography>
               <Typography style={styles.aboutSectionPara}>
-                {packageJson.version}
+                {/*eslint-disable-next-line react-native/no-raw-text */}
+                {` ${packageJson.version}`}
               </Typography>
             </View>
 
@@ -148,7 +149,8 @@ export class AboutScreen extends Component {
                 {languages.t('about.operating_system_abbr')}
               </Typography>
               <Typography style={styles.aboutSectionPara}>
-                {Platform.OS + ' v' + Platform.Version}
+                {/*eslint-disable-next-line react-native/no-raw-text */}
+                {` ${Platform.OS}  v${Platform.Version}`}
               </Typography>
             </View>
 
@@ -157,9 +159,10 @@ export class AboutScreen extends Component {
                 {languages.t('about.dimensions')}
               </Typography>
               <Typography style={styles.aboutSectionPara}>
-                {Math.trunc(Dimensions.get('screen').width) +
-                  ' x ' +
-                  Math.trunc(Dimensions.get('screen').height)}
+                {/*eslint-disable-next-line react-native/no-raw-text */}
+                {` ${Math.trunc(Dimensions.get('screen').width)} x ${Math.trunc(
+                  Dimensions.get('screen').height,
+                )}`}
               </Typography>
             </View>
           </View>

--- a/app/views/About.js
+++ b/app/views/About.js
@@ -22,7 +22,9 @@ import { DEBUG_MODE } from '../constants/storage';
 import { GetStoreData } from '../helpers/General';
 import { disableDebugMode, enableDebugMode } from '../helpers/Intersect';
 
-class AboutScreen extends Component {
+export const ABOUT_SCREEN_NAME = 'AboutScreen';
+
+export class AboutScreen extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -219,5 +221,3 @@ const styles = StyleSheet.create({
     alignItems: 'flex-start',
   },
 });
-
-export default AboutScreen;

--- a/app/views/ChooseProvider.js
+++ b/app/views/ChooseProvider.js
@@ -33,7 +33,9 @@ import { HCAService } from '../services/HCAService';
 
 const { SlideInMenu } = renderers;
 
-class ChooseProviderScreen extends Component {
+export const CHOOSE_PROVIDER_SCREEN_NAME = 'ChooseProviderScreen';
+
+class ChooseProvider extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -489,4 +491,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default withMenuContext(ChooseProviderScreen);
+export const ChooseProviderScreen = withMenuContext(ChooseProvider);

--- a/app/views/Export.js
+++ b/app/views/Export.js
@@ -27,6 +27,8 @@ import { LocationData } from '../services/LocationService';
 
 const base64 = RNFetchBlob.base64;
 
+export const EXPORT_SCREEN_NAME = 'ExportScreen';
+
 export const ExportScreen = ({ navigation }) => {
   const { t } = useTranslation();
   function handleBackPress() {

--- a/app/views/ExposureHistory/ExposureHistory.js
+++ b/app/views/ExposureHistory/ExposureHistory.js
@@ -15,6 +15,8 @@ import { DetailedHistory } from './DetailedHistory';
 
 const NO_HISTORY = [];
 
+export const EXPOSURE_HISTORY_SCREEN_NAME = 'ExposureHistoryScreen';
+
 export const ExposureHistoryScreen = ({ navigation }) => {
   const [history, setHistory] = useState(null);
   const [isLoading, setIsLoading] = useState(true);

--- a/app/views/Import.js
+++ b/app/views/Import.js
@@ -28,7 +28,9 @@ const makeImportResults = (label = '', error = false) => ({
   label,
 });
 
-const ImportScreen = props => {
+export const IMPORT_SCREEN_NAME = 'ImportScreen';
+
+export const ImportScreen = props => {
   const { t } = useTranslation();
   const {
     navigation: { goBack },
@@ -172,4 +174,3 @@ const styles = StyleSheet.create({
     color: colors.RED_TEXT,
   },
 });
-export default ImportScreen;

--- a/app/views/Licenses.js
+++ b/app/views/Licenses.js
@@ -21,6 +21,8 @@ import { Theme } from '../constants/themes';
 const TERMS_OF_USE_URL =
   'https://docs.google.com/document/d/1mtdal_pywsKZVMXLHjjj5eKznipPLP8sM1HwFTIhjo0/edit#';
 
+export const LICENSES_SCREEN_NAME = 'LicensesScreen';
+
 export const LicensesScreen = ({ navigation }) => {
   const { t } = useTranslation();
 

--- a/app/views/LocationTracking.js
+++ b/app/views/LocationTracking.js
@@ -78,9 +78,9 @@ const StateIcon = ({ status, size }) => {
 
 const height = Dimensions.get('window').height;
 
-export const LOCATION_TRACKING_SCREEN_NAME = 'LocationTrackingScreen';
+export const LOCATION_TRACKING_SCREEN_NAME = 'LocationTracking';
 
-export class LocationTracking extends Component {
+export class LocationTrackingScreen extends Component {
   constructor(props) {
     super(props);
 

--- a/app/views/LocationTracking.js
+++ b/app/views/LocationTracking.js
@@ -41,6 +41,10 @@ import { checkIntersect } from '../helpers/Intersect';
 import languages from '../locales/languages';
 import BackgroundTaskServices from '../services/BackgroundTaskService';
 import LocationServices from '../services/LocationService';
+import { EXPORT_SCREEN_NAME } from './Export';
+import { EXPOSURE_HISTORY_SCREEN_NAME } from './ExposureHistory/ExposureHistory';
+import { IMPORT_SCREEN_NAME } from './Import';
+import { SETTINGS_SCREEN_NAME } from './Settings';
 
 const MAYO_COVID_URL = 'https://www.mayoclinic.org/coronavirus-covid-19';
 
@@ -74,7 +78,9 @@ const StateIcon = ({ status, size }) => {
 
 const height = Dimensions.get('window').height;
 
-class LocationTracking extends Component {
+export const LOCATION_TRACKING_SCREEN_NAME = 'LocationTrackingScreen';
+
+export class LocationTracking extends Component {
   constructor(props) {
     super(props);
 
@@ -222,11 +228,11 @@ class LocationTracking extends Component {
   };
 
   export() {
-    this.props.navigation.navigate('ExportScreen', {});
+    this.props.navigation.navigate(EXPORT_SCREEN_NAME, {});
   }
 
   import() {
-    this.props.navigation.navigate('ImportScreen', {});
+    this.props.navigation.navigate(IMPORT_SCREEN_NAME, {});
   }
 
   willParticipate = () => {
@@ -263,7 +269,7 @@ class LocationTracking extends Component {
   }
 
   settings() {
-    this.props.navigation.navigate('SettingsScreen', {});
+    this.props.navigation.navigate(SETTINGS_SCREEN_NAME, {});
   }
 
   getSettings() {
@@ -271,7 +277,7 @@ class LocationTracking extends Component {
       <TouchableOpacity
         style={styles.settingsContainer}
         onPress={() => {
-          this.props.navigation.navigate('SettingsScreen');
+          this.props.navigation.navigate(SETTINGS_SCREEN_NAME);
         }}>
         {/* Is there is a reason there's this imageless image tag here? Can we delete it? */}
         <Image resizeMode={'contain'} />
@@ -366,7 +372,7 @@ class LocationTracking extends Component {
     } else if (this.state.currentState === StateEnum.AT_RISK) {
       buttonLabel = languages.t('label.see_exposure_history');
       buttonFunction = () => {
-        this.props.navigation.navigate('ExposureHistoryScreen');
+        this.props.navigation.navigate(EXPOSURE_HISTORY_SCREEN_NAME);
       };
     } else if (this.state.currentState === StateEnum.UNKNOWN) {
       buttonLabel = languages.t('label.home_enable_location');
@@ -568,5 +574,3 @@ const styles = StyleSheet.create({
     paddingLeft: 20,
   },
 });
-
-export default LocationTracking;

--- a/app/views/News.js
+++ b/app/views/News.js
@@ -22,8 +22,9 @@ const width = Dimensions.get('window').width;
 const height = Dimensions.get('window').height;
 
 export const DEFAULT_NEWS_SITE_URL = 'https://covidsafepaths.org/in-app-news';
+export const NEWS_SCREEN_NAME = 'NewsScreen';
 
-class NewsScreen extends Component {
+export class NewsScreen extends Component {
   constructor(props) {
     super(props);
     let default_news = {
@@ -180,5 +181,3 @@ const styles = StyleSheet.create({
     fontFamily: fontFamily.primarySemiBold,
   },
 });
-
-export default NewsScreen;

--- a/app/views/Settings.js
+++ b/app/views/Settings.js
@@ -19,8 +19,16 @@ import {
   supportedDeviceLanguageOrEnglish,
 } from '../locales/languages';
 import LocationServices from '../services/LocationService';
+import { ABOUT_SCREEN_NAME } from './About';
+import { CHOOSE_PROVIDER_SCREEN_NAME } from './ChooseProvider';
+import { EXPORT_SCREEN_NAME } from './Export';
+import { EXPOSURE_HISTORY_SCREEN_NAME } from './ExposureHistory/ExposureHistory';
+import { LICENSES_SCREEN_NAME } from './Licenses';
+import { NEWS_SCREEN_NAME } from './News';
 import { GoogleMapsImport } from './Settings/GoogleMapsImport';
 import { SettingsItem as Item } from './Settings/SettingsItem';
+
+export const SETTINGS_SCREEN_NAME = 'SettingsScreen';
 
 export const SettingsScreen = ({ navigation }) => {
   const { t } = useTranslation();
@@ -107,22 +115,22 @@ export const SettingsScreen = ({ navigation }) => {
           <Item
             label={t('label.choose_provider_title')}
             description={t('label.choose_provider_subtitle')}
-            onPress={() => navigation.navigate('ChooseProviderScreen')}
+            onPress={() => navigation.navigate(CHOOSE_PROVIDER_SCREEN_NAME)}
           />
           <Item
             label={t('label.news_title')}
             description={t('label.news_subtitle')}
-            onPress={() => navigation.navigate('NewsScreen')}
+            onPress={() => navigation.navigate(NEWS_SCREEN_NAME)}
           />
           <Item
             label={t('label.event_history_title')}
             description={t('label.event_history_subtitle')}
-            onPress={() => navigation.navigate('ExposureHistoryScreen')}
+            onPress={() => navigation.navigate(EXPOSURE_HISTORY_SCREEN_NAME)}
           />
           <Item
             label={t('share.title')}
             description={t('share.subtitle')}
-            onPress={() => navigation.navigate('ExportScreen')}
+            onPress={() => navigation.navigate(EXPORT_SCREEN_NAME)}
             last
           />
         </Section>
@@ -136,11 +144,11 @@ export const SettingsScreen = ({ navigation }) => {
         <Section last>
           <Item
             label={t('label.about_title')}
-            onPress={() => navigation.navigate('AboutScreen')}
+            onPress={() => navigation.navigate(ABOUT_SCREEN_NAME)}
           />
           <Item
             label={t('label.legal_page_title')}
-            onPress={() => navigation.navigate('LicensesScreen')}
+            onPress={() => navigation.navigate(LICENSES_SCREEN_NAME)}
             last
           />
         </Section>

--- a/app/views/Settings/GoogleMapsImport.js
+++ b/app/views/Settings/GoogleMapsImport.js
@@ -7,12 +7,13 @@ import googleMapsIcon from '../../assets/svgs/google-maps-logo';
 import ButtonWrapper from '../../components/ButtonWrapper';
 import { Typography } from '../../components/Typography';
 import Colors from '../../constants/colors';
+import { IMPORT_SCREEN_NAME } from '../Import';
 
 export const GoogleMapsImport = ({ navigation }) => {
   const { t } = useTranslation();
 
   const importPressed = () => {
-    navigation.navigate('ImportScreen');
+    navigation.navigate(IMPORT_SCREEN_NAME);
   };
 
   return (

--- a/app/views/__tests__/Import.spec.js
+++ b/app/views/__tests__/Import.spec.js
@@ -10,7 +10,7 @@ import React from 'react';
 import { Linking } from 'react-native';
 import renderer from 'react-test-renderer';
 
-import Import from '../Import';
+import { ImportScreen } from '../Import';
 
 jest.spyOn(console, 'log').mockImplementation(() => {});
 
@@ -44,19 +44,23 @@ describe('Import component', () => {
 
   it('renders correctly', () => {
     const tree = renderer
-      .create(<Import navigation={navigationMock} />)
+      .create(<ImportScreen navigation={navigationMock} />)
       .toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it('clicking on Google Takeout button leads to open browser page', () => {
-    const { getByTestId } = render(<Import navigation={navigationMock} />);
+    const { getByTestId } = render(
+      <ImportScreen navigation={navigationMock} />,
+    );
     fireEvent(getByTestId('google-takeout-link'), new NativeTestEvent('press'));
     expect(openURLSpy).toHaveBeenCalled();
   });
 
   it('clicking on import Takeout button opens a file picker', async () => {
-    const { getByTestId } = render(<Import navigation={navigationMock} />);
+    const { getByTestId } = render(
+      <ImportScreen navigation={navigationMock} />,
+    );
     await act(async () => {
       await fireEvent(
         getByTestId('google-takeout-import-btn'),

--- a/app/views/__tests__/LocationTracking.spec.js
+++ b/app/views/__tests__/LocationTracking.spec.js
@@ -3,12 +3,12 @@ import 'react-native';
 import { render, wait } from '@testing-library/react-native';
 import React from 'react';
 
-import LocationTracking from '../LocationTracking';
+import { LocationTrackingScreen } from '../LocationTracking';
 
 // TODO(#373): Skipped due to worker not exiting, hanging CI action
 // eslint-disable-next-line jest/no-disabled-tests
 it.skip('renders correctly', async () => {
-  const { asJSON } = render(<LocationTracking />);
+  const { asJSON } = render(<LocationTrackingScreen />);
 
   await wait();
 

--- a/app/views/__tests__/News.spec.js
+++ b/app/views/__tests__/News.spec.js
@@ -1,10 +1,12 @@
 import 'react-native';
+
+import { render, wait } from '@testing-library/react-native';
 import React from 'react';
-import {render, wait} from '@testing-library/react-native';
-import News from '../News';
+
+import { NewsScreen } from '../News';
 
 it('renders correctly', async () => {
-  const {asJSON} = render(<News />);
+  const { asJSON } = render(<NewsScreen />);
   await wait();
 
   expect(asJSON()).toMatchSnapshot();

--- a/app/views/onboarding/Onboarding1.js
+++ b/app/views/onboarding/Onboarding1.js
@@ -25,9 +25,9 @@ import { ONBOARDING2_SCREEN_NAME } from './Onboarding2';
 
 const width = Dimensions.get('window').width;
 
-export const ONBOARDING1_SCREEN_NAME = 'Onboarding1';
+export const ONBOARDING1_SCREEN_NAME = 'Onboarding1Screen';
 
-export class Onboarding1 extends Component {
+export class Onboarding1Screen extends Component {
   constructor(props) {
     super(props);
 

--- a/app/views/onboarding/Onboarding1.js
+++ b/app/views/onboarding/Onboarding1.js
@@ -21,10 +21,13 @@ import NativePicker from '../../components/NativePicker';
 import { Typography } from '../../components/Typography';
 import Colors from '../../constants/colors';
 import fontFamily from '../../constants/fonts';
+import { ONBOARDING2_SCREEN_NAME } from './Onboarding2';
 
 const width = Dimensions.get('window').width;
 
-class Onboarding extends Component {
+export const ONBOARDING1_SCREEN_NAME = 'Onboarding1';
+
+export class Onboarding1 extends Component {
   constructor(props) {
     super(props);
 
@@ -94,7 +97,7 @@ class Onboarding extends Component {
             <View style={styles.footerContainer}>
               <EulaModal
                 continueFunction={() =>
-                  this.props.navigation.replace('Onboarding2')
+                  this.props.navigation.replace(ONBOARDING2_SCREEN_NAME)
                 }
                 selectedLocale={this.state.locale}
               />
@@ -155,5 +158,3 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
   },
 });
-
-export default Onboarding;

--- a/app/views/onboarding/Onboarding2.js
+++ b/app/views/onboarding/Onboarding2.js
@@ -17,9 +17,9 @@ import { ONBOARDING3_SCREEN_NAME } from './Onboarding3';
 
 const width = Dimensions.get('window').width;
 
-export const ONBOARDING2_SCREEN_NAME = 'Onboarding2';
+export const ONBOARDING2_SCREEN_NAME = 'Onboarding2Screen';
 
-export const Onboarding2 = props => {
+export const Onboarding2Screen = props => {
   return (
     <View style={styles.mainContainer}>
       <StatusBar

--- a/app/views/onboarding/Onboarding2.js
+++ b/app/views/onboarding/Onboarding2.js
@@ -13,10 +13,13 @@ import { Type, Typography } from '../../components/Typography';
 import Colors from '../../constants/colors';
 import fontFamily from '../../constants/fonts';
 import languages from '../../locales/languages';
+import { ONBOARDING3_SCREEN_NAME } from './Onboarding3';
 
 const width = Dimensions.get('window').width;
 
-const Onboarding = props => {
+export const ONBOARDING2_SCREEN_NAME = 'Onboarding2';
+
+export const Onboarding2 = props => {
   return (
     <View style={styles.mainContainer}>
       <StatusBar
@@ -40,7 +43,7 @@ const Onboarding = props => {
         <ButtonWrapper
           title={languages.t('label.launch_next')}
           onPress={() => {
-            props.navigation.replace('Onboarding3');
+            props.navigation.replace(ONBOARDING3_SCREEN_NAME);
           }}
           buttonColor={Colors.WHITE}
           bgColor={Colors.VIOLET_BUTTON}
@@ -86,5 +89,3 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
   },
 });
-
-export default Onboarding;

--- a/app/views/onboarding/Onboarding3.js
+++ b/app/views/onboarding/Onboarding3.js
@@ -13,10 +13,13 @@ import { Type, Typography } from '../../components/Typography';
 import Colors from '../../constants/colors';
 import fontFamily from '../../constants/fonts';
 import languages from '../../locales/languages';
+import { ONBOARDING4_SCREEN_NAME } from './Onboarding4';
 
 const width = Dimensions.get('window').width;
 
-const Onboarding = props => {
+export const ONBOARDING3_SCREEN_NAME = 'Onboarding3';
+
+export const Onboarding3 = props => {
   return (
     <View style={styles.mainContainer}>
       <StatusBar
@@ -40,7 +43,7 @@ const Onboarding = props => {
         <ButtonWrapper
           title={languages.t('label.launch_next')}
           onPress={() => {
-            props.navigation.replace('Onboarding4');
+            props.navigation.replace(ONBOARDING4_SCREEN_NAME);
           }}
           buttonColor={Colors.WHITE}
           bgColor={Colors.VIOLET_BUTTON}
@@ -86,5 +89,3 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
   },
 });
-
-export default Onboarding;

--- a/app/views/onboarding/Onboarding3.js
+++ b/app/views/onboarding/Onboarding3.js
@@ -17,9 +17,9 @@ import { ONBOARDING4_SCREEN_NAME } from './Onboarding4';
 
 const width = Dimensions.get('window').width;
 
-export const ONBOARDING3_SCREEN_NAME = 'Onboarding3';
+export const ONBOARDING3_SCREEN_NAME = 'Onboarding3Screen';
 
-export const Onboarding3 = props => {
+export const Onboarding3Screen = props => {
   return (
     <View style={styles.mainContainer}>
       <StatusBar

--- a/app/views/onboarding/Onboarding4.js
+++ b/app/views/onboarding/Onboarding4.js
@@ -13,10 +13,13 @@ import { Type, Typography } from '../../components/Typography';
 import Colors from '../../constants/colors';
 import fontFamily from '../../constants/fonts';
 import languages from '../../locales/languages';
+import { ONBOARDING5_SCREEN_NAME } from './Onboarding5';
 
 const width = Dimensions.get('window').width;
 
-const Onboarding = props => {
+export const ONBOARDING4_SCREEN_NAME = 'Onboarding4';
+
+export const Onboarding4 = props => {
   return (
     <View style={styles.mainContainer}>
       <StatusBar
@@ -40,7 +43,7 @@ const Onboarding = props => {
         <ButtonWrapper
           title={languages.t('label.launch_set_up_phone')}
           onPress={() => {
-            props.navigation.replace('Onboarding5');
+            props.navigation.replace(ONBOARDING5_SCREEN_NAME);
           }}
           buttonColor={Colors.WHITE}
           bgColor={Colors.VIOLET_BUTTON}
@@ -86,5 +89,3 @@ const styles = StyleSheet.create({
     alignSelf: 'center',
   },
 });
-
-export default Onboarding;

--- a/app/views/onboarding/Onboarding4.js
+++ b/app/views/onboarding/Onboarding4.js
@@ -17,9 +17,9 @@ import { ONBOARDING5_SCREEN_NAME } from './Onboarding5';
 
 const width = Dimensions.get('window').width;
 
-export const ONBOARDING4_SCREEN_NAME = 'Onboarding4';
+export const ONBOARDING4_SCREEN_NAME = 'Onboarding4Screen';
 
-export const Onboarding4 = props => {
+export const Onboarding4Screen = props => {
   return (
     <View style={styles.mainContainer}>
       <StatusBar

--- a/app/views/onboarding/Onboarding5.js
+++ b/app/views/onboarding/Onboarding5.js
@@ -29,6 +29,7 @@ import { PARTICIPATE } from '../../constants/storage';
 import { SetStoreData } from '../../helpers/General';
 import languages from '../../locales/languages';
 import { HCAService } from '../../services/HCAService';
+import { LOCATION_TRACKING_SCREEN_NAME } from '../LocationTracking';
 
 const width = Dimensions.get('window').width;
 
@@ -44,6 +45,8 @@ const StepEnum = {
   HCA_SUBSCRIPTION: 2,
   DONE: 3,
 };
+
+export const ONBOARDING5_SCREEN_NAME = 'Onboarding5';
 
 const PermissionDescription = ({ title, status }) => {
   let icon;
@@ -69,7 +72,7 @@ const PermissionDescription = ({ title, status }) => {
   );
 };
 
-class Onboarding extends Component {
+export class Onboarding5 extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -292,7 +295,7 @@ class Onboarding extends Component {
           this.state.locationPermission === PermissionStatusEnum.GRANTED,
         );
         SetStoreData('ONBOARDING_DONE', true);
-        this.props.navigation.replace('LocationTrackingScreen');
+        this.props.navigation.replace(LOCATION_TRACKING_SCREEN_NAME);
     }
   }
 
@@ -520,5 +523,3 @@ const styles = StyleSheet.create({
     paddingTop: 15,
   },
 });
-
-export default Onboarding;

--- a/app/views/onboarding/Onboarding5.js
+++ b/app/views/onboarding/Onboarding5.js
@@ -46,7 +46,7 @@ const StepEnum = {
   DONE: 3,
 };
 
-export const ONBOARDING5_SCREEN_NAME = 'Onboarding5';
+export const ONBOARDING5_SCREEN_NAME = 'Onboarding5Screen';
 
 const PermissionDescription = ({ title, status }) => {
   let icon;
@@ -72,7 +72,7 @@ const PermissionDescription = ({ title, status }) => {
   );
 };
 
-export class Onboarding5 extends Component {
+export class Onboarding5Screen extends Component {
   constructor(props) {
     super(props);
     this.state = {

--- a/e2e/helpers/onboarding.js
+++ b/e2e/helpers/onboarding.js
@@ -1,26 +1,26 @@
 import EnableAuthoritySubscription from '../pages/EnableAuthoritySubscription.po.js';
 import FinishSetup from '../pages/FinishSetup.po.js';
-import Onboarding1 from '../pages/Onboarding1.po.js';
-import Onboarding2 from '../pages/Onboarding2.po.js';
-import Onboarding3 from '../pages/Onboarding3.po.js';
-import Onboarding4 from '../pages/Onboarding4.po.js';
+import Onboarding1Screen from '../pages/Onboarding1Screen.po.js';
+import Onboarding2Screen from '../pages/Onboarding2Screen.po.js';
+import Onboarding3Screen from '../pages/Onboarding3Screen.po.js';
+import Onboarding4Screen from '../pages/Onboarding4Screen.po.js';
 import SignEula from '../pages/SignEula.po.js';
 
 export const navigateThroughPermissions = async languageStrings => {
-  await Onboarding1.isOnScreen(languageStrings);
-  await Onboarding1.tapButton(languageStrings);
+  await Onboarding1Screen.isOnScreen(languageStrings);
+  await Onboarding1Screen.tapButton(languageStrings);
 
   await SignEula.sign(languageStrings);
   await SignEula.tapButton(languageStrings);
 
-  await Onboarding2.isOnScreen(languageStrings);
-  await Onboarding2.tapButton(languageStrings);
+  await Onboarding2Screen.isOnScreen(languageStrings);
+  await Onboarding2Screen.tapButton(languageStrings);
 
-  await Onboarding3.isOnScreen(languageStrings);
-  await Onboarding3.tapButton(languageStrings);
+  await Onboarding3Screen.isOnScreen(languageStrings);
+  await Onboarding3Screen.tapButton(languageStrings);
 
-  await Onboarding4.isOnScreen(languageStrings);
-  await Onboarding4.tapButton(languageStrings);
+  await Onboarding4Screen.isOnScreen(languageStrings);
+  await Onboarding4Screen.tapButton(languageStrings);
 };
 
 export const navigateThroughOnboarding = async languageStrings => {

--- a/e2e/onboarding/Onboarding.spec.js
+++ b/e2e/onboarding/Onboarding.spec.js
@@ -1,8 +1,8 @@
 import { languages } from '../helpers/language';
-import Onboarding1 from '../pages/Onboarding1.po.js';
-import Onboarding2 from '../pages/Onboarding2.po.js';
-import Onboarding3 from '../pages/Onboarding3.po.js';
-import Onboarding4 from '../pages/Onboarding4.po.js';
+import Onboarding1Screen from '../pages/Onboarding1Screen.po.js';
+import Onboarding2Screen from '../pages/Onboarding2Screen.po.js';
+import Onboarding3Screen from '../pages/Onboarding3Screen.po.js';
+import Onboarding4Screen from '../pages/Onboarding4Screen.po.js';
 import SignEula from '../pages/SignEula.po.js';
 
 describe.each(languages)(
@@ -20,25 +20,25 @@ describe.each(languages)(
 
     describe('Onboarding visual appearance', () => {
       it('Navigates through the onboarding without visual regression', async () => {
-        await Onboarding1.isOnScreen(languageStrings);
-        await Onboarding1.takeScreenshot();
-        await Onboarding1.tapButton(languageStrings);
+        await Onboarding1Screen.isOnScreen(languageStrings);
+        await Onboarding1Screen.takeScreenshot();
+        await Onboarding1Screen.tapButton(languageStrings);
 
         await SignEula.sign(languageStrings);
         await SignEula.takeScreenshot();
         await SignEula.tapButton(languageStrings);
 
-        await Onboarding2.isOnScreen(languageStrings);
-        await Onboarding2.takeScreenshot();
-        await Onboarding2.tapButton(languageStrings);
+        await Onboarding2Screen.isOnScreen(languageStrings);
+        await Onboarding2Screen.takeScreenshot();
+        await Onboarding2Screen.tapButton(languageStrings);
 
-        await Onboarding3.isOnScreen(languageStrings);
-        await Onboarding3.takeScreenshot();
-        await Onboarding3.tapButton(languageStrings);
+        await Onboarding3Screen.isOnScreen(languageStrings);
+        await Onboarding3Screen.takeScreenshot();
+        await Onboarding3Screen.tapButton(languageStrings);
 
-        await Onboarding4.isOnScreen(languageStrings);
-        await Onboarding4.takeScreenshot();
-        await Onboarding4.tapButton(languageStrings);
+        await Onboarding4Screen.isOnScreen(languageStrings);
+        await Onboarding4Screen.takeScreenshot();
+        await Onboarding4Screen.tapButton(languageStrings);
       });
 
       afterAll(async () => {

--- a/e2e/onboarding/UnsignedEula.spec.js
+++ b/e2e/onboarding/UnsignedEula.spec.js
@@ -1,5 +1,5 @@
 import { languages } from '../helpers/language';
-import Onboarding1 from '../pages/Onboarding1.po.js';
+import Onboarding1Screen from '../pages/Onboarding1Screen.po.js';
 import SignEula from '../pages/SignEula.po.js';
 
 describe.each(languages)(
@@ -18,8 +18,8 @@ describe.each(languages)(
 
     describe('Cannot continue without signing the EULA', () => {
       it('Does not allow the user to proceed', async () => {
-        await Onboarding1.isOnScreen(languageStrings);
-        await Onboarding1.tapButton(languageStrings);
+        await Onboarding1Screen.isOnScreen(languageStrings);
+        await Onboarding1Screen.tapButton(languageStrings);
 
         await SignEula.tapButton(languageStrings);
         await device.takeScreenshot('Unsigned Eula Continue Attempt');

--- a/e2e/pages/Onboarding1.po.js
+++ b/e2e/pages/Onboarding1.po.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 const screenshotText = 'Onboarding - Page 1';
 
-class Onboarding1 {
+class Onboarding1Screen {
   async tapButton(languageStrings) {
     await element(by.label(languageStrings.label.launch_get_started)).tap();
   }
@@ -17,4 +17,4 @@ class Onboarding1 {
   }
 }
 
-export default new Onboarding1();
+export default new Onboarding1Screen();

--- a/e2e/pages/Onboarding2.po.js
+++ b/e2e/pages/Onboarding2.po.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 const screenshotText = 'Onboarding - Page 2';
 
-class Onboarding2 {
+class Onboarding2Screen {
   async tapButton(languageStrings) {
     await element(by.label(languageStrings.label.launch_next)).tap();
   }
@@ -18,4 +18,4 @@ class Onboarding2 {
   }
 }
 
-export default new Onboarding2();
+export default new Onboarding2Screen();

--- a/e2e/pages/Onboarding3.po.js
+++ b/e2e/pages/Onboarding3.po.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 const screenshotText = 'Onboarding - Page 3';
 
-class Onboarding3 {
+class Onboarding3Screen {
   async tapButton(languageStrings) {
     await element(by.label(languageStrings.label.launch_next)).tap();
   }
@@ -18,4 +18,4 @@ class Onboarding3 {
   }
 }
 
-export default new Onboarding3();
+export default new Onboarding3Screen();

--- a/e2e/pages/Onboarding4.po.js
+++ b/e2e/pages/Onboarding4.po.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 const screenshotText = 'Onboarding - Page 4';
 
-class Onboarding4 {
+class Onboarding4Screen {
   async tapButton(languageStrings) {
     await element(by.label(languageStrings.label.launch_set_up_phone)).tap();
   }
@@ -18,4 +18,4 @@ class Onboarding4 {
   }
 }
 
-export default new Onboarding4();
+export default new Onboarding4Screen();


### PR DESCRIPTION
Signed-off-by: Patrick Erichsen <patrick.a.erichsen@gmail.com>

<!-- Please read https://github.com/tripleblindmarket/covid-safe-paths/wiki/Pull-Request-Best-Practices for recommended best practices before opening your first pull request -->

#### Description:

Removes magic strings that we were using across the app for screen navigation and replaced them with exported `const`s from the respective screen components.

Also performs a few misc cleanup tasks:

- Gets rid of `default` exports and replaces with named exports to follow style guidelines
- Cleans up the `componentDidMount` method for `Entry.js`
- Adds space for formatting on  info at bottom of `About` screen

#### Linked issues:

N/A

#### Screenshots:

N/A

#### How to test:

Walkthrough all of the screens in the app and confirm that navigation is functioning properly.